### PR TITLE
RFC: use boolean columns instead of integers

### DIFF
--- a/db/migrate/20130615150810_use_boolean_columns.rb
+++ b/db/migrate/20130615150810_use_boolean_columns.rb
@@ -1,0 +1,13 @@
+class UseBooleanColumns < ActiveRecord::Migration
+  def up
+    change_column :events, :public, :boolean, default: false
+    change_column :people, :email_public, :boolean, default: true
+    change_column :rooms, :public, :boolean, default: true
+  end
+
+  def down
+    change_column :events, :public, :integer
+    change_column :people, :email_public, :integer
+    change_column :rooms, :public, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,8 +16,8 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
   create_table "availabilities", :force => true do |t|
     t.integer  "person_id"
     t.integer  "conference_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.datetime "start_date"
     t.datetime "end_date"
     t.integer  "day_id"
@@ -29,26 +29,26 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.date     "hard_deadline"
     t.text     "welcome_text"
     t.integer  "conference_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.string   "info_url"
     t.string   "contact_email"
   end
 
   create_table "conferences", :force => true do |t|
-    t.string   "acronym",                                    :null => false
-    t.string   "title",                                      :null => false
-    t.string   "timezone",                                   :null => false
-    t.integer  "timeslot_duration",                          :null => false
-    t.integer  "default_timeslots",                          :null => false
-    t.integer  "max_timeslots",                              :null => false
-    t.integer  "feedback_enabled",                           :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string   "acronym",                                       :null => false
+    t.string   "title",                                         :null => false
+    t.string   "timezone",                :default => "Berlin", :null => false
+    t.integer  "timeslot_duration",       :default => 15,       :null => false
+    t.integer  "default_timeslots",       :default => 4,        :null => false
+    t.integer  "max_timeslots",           :default => 20,       :null => false
+    t.boolean  "feedback_enabled",        :default => false,    :null => false
+    t.datetime "created_at",                                    :null => false
+    t.datetime "updated_at",                                    :null => false
     t.string   "email"
     t.string   "program_export_base_url"
     t.string   "schedule_version"
-    t.boolean  "schedule_public",         :default => false, :null => false
+    t.boolean  "schedule_public",         :default => false,    :null => false
     t.string   "color"
     t.string   "ticket_type"
   end
@@ -59,8 +59,8 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.integer  "person_id"
     t.string   "conflict_type"
     t.string   "severity"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",           :null => false
+    t.datetime "updated_at",           :null => false
   end
 
   create_table "days", :force => true do |t|
@@ -76,8 +76,8 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "attachment_content_type"
     t.integer  "attachment_file_size"
     t.datetime "attachment_updated_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.boolean  "public",                  :default => true
   end
 
@@ -85,18 +85,18 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.integer  "event_id"
     t.float    "rating"
     t.text     "comment"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "event_people", :force => true do |t|
-    t.integer  "event_id",           :null => false
-    t.integer  "person_id",          :null => false
-    t.string   "event_role",         :null => false
+    t.integer  "event_id",                                    :null => false
+    t.integer  "person_id",                                   :null => false
+    t.string   "event_role",         :default => "submitter", :null => false
     t.string   "role_state"
     t.string   "comment"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                  :null => false
+    t.datetime "updated_at",                                  :null => false
     t.string   "confirmation_token"
   end
 
@@ -105,36 +105,36 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.integer  "person_id"
     t.float    "rating"
     t.text     "comment"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "events", :force => true do |t|
-    t.integer  "conference_id",         :null => false
-    t.string   "title",                 :null => false
+    t.integer  "conference_id",                             :null => false
+    t.string   "title",                                     :null => false
     t.string   "subtitle"
-    t.string   "event_type"
+    t.string   "event_type",            :default => "talk"
     t.integer  "time_slots"
-    t.string   "state",                 :null => false
+    t.string   "state",                 :default => "new",  :null => false
     t.string   "language"
     t.datetime "start_time"
     t.text     "abstract"
     t.text     "description"
-    t.integer  "public"
+    t.boolean  "public",                :default => true
     t.string   "logo_file_name"
     t.string   "logo_content_type"
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
     t.integer  "track_id"
     t.integer  "room_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.float    "average_rating"
-    t.integer  "event_ratings_count"
+    t.integer  "event_ratings_count",   :default => 0
     t.text     "note"
     t.text     "submission_note"
-    t.integer  "speaker_count"
-    t.integer  "event_feedbacks_count"
+    t.integer  "speaker_count",         :default => 0
+    t.integer  "event_feedbacks_count", :default => 0
     t.float    "average_feedback"
   end
 
@@ -142,16 +142,16 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.integer  "person_id"
     t.string   "im_type"
     t.string   "im_address"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "languages", :force => true do |t|
     t.string   "code"
     t.integer  "attachable_id"
     t.string   "attachable_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
   end
 
   create_table "links", :force => true do |t|
@@ -159,8 +159,8 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "url",           :null => false
     t.integer  "linkable_id",   :null => false
     t.string   "linkable_type", :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
   end
 
   create_table "notification_translations", :force => true do |t|
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "last_name",           :default => ""
     t.string   "public_name",                            :null => false
     t.string   "email",                                  :null => false
-    t.integer  "email_public"
+    t.boolean  "email_public"
     t.string   "gender"
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
@@ -196,8 +196,8 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.datetime "avatar_updated_at"
     t.text     "abstract"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                             :null => false
+    t.datetime "updated_at",                             :null => false
     t.integer  "user_id"
     t.text     "note"
     t.boolean  "include_in_mailings", :default => false, :null => false
@@ -207,17 +207,17 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.integer  "person_id"
     t.string   "phone_type"
     t.string   "phone_number"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",   :null => false
+    t.datetime "updated_at",   :null => false
   end
 
   create_table "rooms", :force => true do |t|
-    t.integer  "conference_id", :null => false
-    t.string   "name",          :null => false
+    t.integer  "conference_id",                   :null => false
+    t.string   "name",                            :null => false
     t.integer  "size"
-    t.integer  "public"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.boolean  "public",        :default => true
+    t.datetime "created_at",                      :null => false
+    t.datetime "updated_at",                      :null => false
     t.integer  "rank"
   end
 
@@ -236,33 +236,33 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "url"
     t.string   "user"
     t.string   "password"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.string   "queue"
   end
 
   create_table "tickets", :force => true do |t|
     t.integer  "event_id",         :null => false
     t.string   "remote_ticket_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",       :null => false
+    t.datetime "updated_at",       :null => false
   end
 
   create_table "tracks", :force => true do |t|
     t.integer  "conference_id"
-    t.string   "name",          :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "color"
+    t.string   "name",                                :null => false
+    t.datetime "created_at",                          :null => false
+    t.datetime "updated_at",                          :null => false
+    t.string   "color",         :default => "fefd7f"
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                               :null => false
-    t.string   "password_digest",      :limit => 128, :null => false
+    t.string   "email",                :default => "",          :null => false
+    t.string   "password_digest",      :default => "",          :null => false
     t.string   "reset_password_token"
-    t.string   "remember_token"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count"
+    t.string   "remember_token"
+    t.integer  "sign_in_count",        :default => 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -270,13 +270,17 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "role"
+    t.datetime "created_at",                                    :null => false
+    t.datetime "updated_at",                                    :null => false
+    t.string   "role",                 :default => "submitter"
     t.string   "pentabarf_salt"
     t.string   "pentabarf_password"
     t.integer  "call_for_papers_id"
   end
+
+  add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true
+  add_index "users", ["email"], :name => "index_users_on_email", :unique => true
+  add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
   create_table "versions", :force => true do |t|
     t.string   "item_type",       :null => false
@@ -290,5 +294,7 @@ ActiveRecord::Schema.define(:version => 20130525102656) do
     t.string   "associated_type"
     t.text     "object_changes"
   end
+
+  add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"
 
 end


### PR DESCRIPTION
The schema.rb created by migrations differs from the versioned schema.rb
file. This patch merges the generated schema file and adds migrations to
convert integer columns into boolean columns as needed.
