### PR TITLE
extracts all the tabs for people into a shared file

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def active_class?(*paths)
+    active = false
+    paths.each { |path| active ||= current_page?(path) }
+    active ? 'active' : nil
+  end
 
   def image_box(image, size)
     content_tag(:div, class: "image #{size}") do

--- a/app/views/availabilities/edit.html.haml
+++ b/app/views/availabilities/edit.html.haml
@@ -2,12 +2,7 @@
   .page-header
     .pull-right
     %h1 Person: #{@person.full_name}
-  %ul.tabs
-    %li= link_to "Profile", @person
-    - if can? :manage, @user
-      %li= link_to "User account", person_user_path(@person)
-    %li.active= link_to "Availability", person_availability_path(@person)
-    %li= link_to "Feedback", feedbacks_people_path(:id => @person.id)
+  = render 'shared/people_tabs'
   .row
     .span16
       = render 'form'

--- a/app/views/availabilities/new.html.haml
+++ b/app/views/availabilities/new.html.haml
@@ -2,12 +2,12 @@
   .page-header
     .pull-right
     %h1 Person: #{@person.full_name}
-  %ul.tabs
-    %li= link_to "Profile", @person
-    - if can? :manage, @user
-      %li= link_to "User account", person_user_path(@person)
-    %li.active= link_to "Availability", new_person_availability_path(@person)
-    %li= link_to "Feedback", feedbacks_people_path(:id => @person.id)
+  = render 'shared/people_tabs'
   .row
     .span16
-      = render 'form'
+      = content do
+        = inner do
+          %p
+            #{@person.full_name} does not currently have any availabilities.
+            You need to submit this form.
+          = render 'form'

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -1,15 +1,7 @@
 %section
   .page-header
     %h1 Edit Person: #{@person.full_name}
-  %ul.tabs
-    %li.active= link_to "Profile", @person
-    - if can? :manage, @user or can? :manage, User
-      %li= link_to "User account", person_user_path(@person)
-    - if @person.availabilities_in(@conference).count == 0
-      %li= link_to "Availability", new_person_availability_path(@person)
-    - else
-      %li= link_to "Availability", edit_person_availability_path(@person)
-    %li= link_to "Feedback", feedbacks_people_path(:id => @person.id)
+  = render 'shared/people_tabs'
   .row
     .span16
       = render 'form'

--- a/app/views/people/feedbacks.html.haml
+++ b/app/views/people/feedbacks.html.haml
@@ -5,17 +5,9 @@
         = action_button "primary", "Edit person", edit_person_path(@person), :title => "Edit this person's data."
       - if can? :control, Person
         = action_button "add", "Add person", new_person_path, :title => "Add a new person."
-    %h1 Person: #{@person.full_name} 
-  %ul.tabs
-    %li= link_to "Profile", @person
-    - if can? :manage, @user
-      %li= link_to "User account", person_user_path(@person)
-    - if @person.availabilities_in(@conference).count == 0
-      %li= link_to "Availability", new_person_availability_path(@person)
-    - else
-      %li= link_to "Availability", edit_person_availability_path(@person)
-    %li.active= link_to "Feedback", feedbacks_people_path(:id => @person.id)
-  .row 
+    %h1 Person: #{@person.full_name}
+  = render 'shared/people_tabs'
+  .row
     .span16
       %h2 Basic information
   .row 

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -5,17 +5,9 @@
         = action_button "primary", "Edit person", edit_person_path(@person), :title => "Edit this person's data."
       - if can? :control, Person
         = action_button "add", "Add person", new_person_path, :title => "Add a new person."
-    %h1 Person: #{@person.full_name} 
-  %ul.tabs
-    %li.active= link_to "Profile", @person
-    - if can? :manage, @user or can? :manage, User
-      %li= link_to "User account", person_user_path(@person)
-    - if @person.availabilities_in(@conference).count == 0
-      %li= link_to "Availability", new_person_availability_path(@person)
-    - else
-      %li= link_to "Availability", edit_person_availability_path(@person)
-    %li= link_to "Feedback", feedbacks_people_path(:id => @person.id)
-  .row 
+    %h1 Person: #{@person.full_name}
+  = render 'shared/people_tabs'
+  .row
     .span6 
       %h2 Basic information
       %p

--- a/app/views/shared/_people_tabs.html.haml
+++ b/app/views/shared/_people_tabs.html.haml
@@ -1,0 +1,12 @@
+%ul.tabs
+  %li{class: active_class?(person_path(@person), edit_person_path(@person))}= link_to "Profile", @person
+  - if can? :manage, @person.user or can? :manage, User
+    - if @person.user.nil?
+      %li{class: active_class?(new_person_user_path(@person))}= link_to "User account", new_person_user_path(@person)
+    - else
+      %li{class: active_class?(person_user_path(@person), edit_person_user_path(@person))}= link_to "User account", person_user_path(@person)
+  - if @person.availabilities_in(@conference).count == 0
+    %li{class: active_class?(new_person_availability_path(@person))}= link_to "Availability", new_person_availability_path(@person)
+  - else
+    %li{class: active_class?(edit_person_availability_path(@person))}= link_to "Availability", edit_person_availability_path(@person)
+  %li{class: active_class?(feedbacks_people_path)}= link_to "Feedback", feedbacks_people_path(:id => @person.id)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,7 @@
 %section
   .page-header
     %h1 Edit Account: #{@person.full_name}
+  = render 'shared/people_tabs'
   .row
     .span16
       = render 'form'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,11 +1,10 @@
-= block do
-  %ul.tabs
-    %li.first= link_to "Profile", @person
-    %li.active= link_to "User account", person_user_path(@person)
+%section
+  .page-header
+    %h1 Create account for #{@person.full_name}
+  = render 'shared/people_tabs'
   .row
     .span16
       = content do
-        %h2 Create account for #{@person.full_name}
         = inner do
           %p
             #{@person.full_name} does not currently have a user account and thus cannot login.

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,14 +3,7 @@
     .pull-right
       = action_button "primary", "Edit user account", edit_person_user_path(@person), :title => "Edit this user account."
     %h1 Person: #{@person.full_name}
-  %ul.tabs
-    %li= link_to "Profile", @person
-    %li.active= link_to "User account", person_user_path(@person)
-    - if @person.availabilities_in(@conference).count == 0
-      %li= link_to "Availability", new_person_availability_path(@person)
-    - else
-      %li= link_to "Availability", edit_person_availability_path(@person)
-    %li= link_to "Feedback", feedbacks_people_path(:id => @person.id)
+  = render 'shared/people_tabs'
   .row
     .span16
       %p


### PR DESCRIPTION
The tabs are shown as active if one of the paths matches. There are probably a few paths missing. If this works out, the same could be done for other top level actions which make heavy use of nested attributes, like the conference view.
