### PR TITLE
Minor bugfix: conference - speaker availabilities relation

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -8,6 +8,7 @@ class Conference < ActiveRecord::Base
   has_many :days, dependent: :destroy
   has_many :rooms, dependent: :destroy
   has_many :tracks, dependent: :destroy
+  has_many :availabilities, dependent: :destroy
   has_many :languages, as: :attachable, dependent: :destroy
 
   acts_as_indexed fields: [:title, :acronym ]


### PR DESCRIPTION
Hi.

This is a very small pull request from the LinuxTag team mainly to get a dialogue working with you guys ;)
Today's patch fixes that speaker availabilities should be destroyed upon deletion of a conference.

Best,
Marko
