### PR TITLE
Komma im json nachgetragen.

### DIFF
--- a/app/views/public/schedule/index.json.erb
+++ b/app/views/public/schedule/index.json.erb
@@ -39,7 +39,7 @@
                     ],
                     "links": [
                       <% event.links.each do |link| %>
-                        {"url": "<%= link.url %>", "title": "<%= link.title%>"}
+                        {"url": "<%= link.url %>", "title": "<%= link.title%>"}<% if event.links.last.id != link.id %>,<% end %>
                       <% end %>
                     ]
                   }<% if room.events.public.accepted.scheduled_on(day).order(:start_time).last.id != event.id %>,<% end %>


### PR DESCRIPTION
Hier wurde das Komma vergessen, somit bleibt das json File unparsbar wenn jemand mehr als einen Link hinterlegt hat.
