### PR TITLE
Added unambiguous date to export

### DIFF
--- a/app/views/public/schedule/index.xml.haml
+++ b/app/views/public/schedule/index.xml.haml
@@ -16,6 +16,7 @@
         %room{:name => room.name}
           - room.events.public.accepted.scheduled_on(day).order(:start_time).each do |event|
             %event{:id=>event.id, :guid=>event.guid} 
+              %date= event.start_time.iso8601
               %start= event.start_time.strftime('%H:%M')
               %duration= format_time_slots(event.time_slots)
               %room= room.name


### PR DESCRIPTION
Since `<day_change>` isn't included in `<conference>` anymore and `day.start/end` aren't exported it's impossible for external software that depends on the Fahrplan to not guess the real date an event takes places.

Attached is an untested proposal to add an unambiguous date to the xml export. This should probably be added to the json export too, if accepted in this form.
