### PR TITLE
Guard against nil ratings.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -101,7 +101,7 @@ class Event < ActiveRecord::Base
   end
 
   def feedback_standard_deviation
-    arr = self.event_feedbacks.map(&:rating)
+    arr = self.event_feedbacks.map(&:rating).reject(&:nil?)
     return if arr.count < 1
 
     n = arr.count


### PR DESCRIPTION
Even though this is a really small change, I am torn on this and would like someone else to either merge or reject this:

This fixes the calculation of the standard deviation in cases where there is an event feedback without numerical rating.

Originally, it sufficed to enter a feedback comment and the numerical rating was not mandatory. These days there is a validation that makes the rating a required value.

That is why older frab installations may still have records where rating is nil. FrOSCon has them. But if FrOSCon's is the only installation that is affected, I would not want to burden everyone else with the extra loop :confused: 
