### PR TITLE
Include event type in speakers.json

### DIFF
--- a/app/views/public/schedule/speakers.json.jbuilder
+++ b/app/views/public/schedule/speakers.json.jbuilder
@@ -14,6 +14,7 @@ json.schedule_speakers do
       json.id event.id
       json.title event.title
       json.logo event.logo_path
+      json.type event.event_type
     end
   end
 end


### PR DESCRIPTION
It doesn't seem like private information, and I'm using it for https://www.emfcamp.org/talks/
