### PR TITLE
Public events view improvements

### DIFF
--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -54,7 +54,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def events
-    @events = @conference.events.public.confirmed.scheduled.sort {|a,b|
+    @events = @conference.events.public.confirmed.sort {|a,b|
       a.to_sortable <=> b.to_sortable
     }
   end

--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -60,7 +60,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def event
-    @event = @conference.events.public.confirmed.scheduled.find(params[:id])
+    @event = @conference.events.public.confirmed.find(params[:id])
     @concurrent_events = @conference.events.public.confirmed.scheduled.where( start_time: @event.start_time )
     respond_to do |format|
       format.html

--- a/app/views/public/schedule/event.html.haml
+++ b/app/views/public/schedule/event.html.haml
@@ -9,12 +9,13 @@
 .column.left#details
   %h3= t '.info'
   %p
-    %b #{t '.day'}:
-    = link_to l(@event.start_time.to_date), public_schedule_path(:day => @conference.day_at(@event.start_time))
-    %br/
-    %b #{t '.start_time'}:
-    = l @event.start_time, :format => :time
-    %br/
+    - if @event.start_time
+      %b #{t '.day'}:
+      = link_to l(@event.start_time.to_date), public_schedule_path(:day => @conference.day_at(@event.start_time))
+      %br/
+      %b #{t '.start_time'}:
+      = l @event.start_time, :format => :time
+      %br/
     %b #{t '.duration'}:
     = format_time_slots(@event.time_slots)
     %br/
@@ -30,7 +31,8 @@
       = @event.language
   %h3 #{t '.links'}:
   %ul
-    %li= link_to "iCalendar", public_event_path(id: @event.id, format: :ics)
+    - if @event.start_time
+      %li= link_to "iCalendar", public_event_path(id: @event.id, format: :ics)
     - @event.links.each do |link|
       %li= link_to link.title, link.url
   - if @event.event_attachments.public.any?

--- a/app/views/public/schedule/events.json.jbuilder
+++ b/app/views/public/schedule/events.json.jbuilder
@@ -5,6 +5,14 @@ json.conference_events do
     json.title event.title
     json.logo event.logo_path
     json.type event.event_type
+    if event.start_time and event.room
+      json.start_time event.start_time
+      json.end_time event.end_time
+      json.room do
+        json.name event.room.name
+        json.id event.room.id
+      end
+    end
     json.abstract event.abstract
     json.speakers event.speakers do |person|
       json.id person.id

--- a/app/views/public/schedule/events.json.jbuilder
+++ b/app/views/public/schedule/events.json.jbuilder
@@ -1,0 +1,22 @@
+json.conference_events do
+  json.version @conference.schedule_version if @conference.schedule_version.present?
+  json.events @events do |event|
+    json.id event.id
+    json.title event.title
+    json.logo event.logo_path
+    json.type event.event_type
+    json.abstract event.abstract
+    json.speakers event.speakers do |person|
+      json.id person.id
+      json.image person.avatar_path
+      json.full_public_name person.full_public_name
+      json.abstract person.abstract
+      json.description person.description
+      json.links person.links do |link|
+        json.url url_for(link.url)
+        json.title link.title
+      end
+    end
+  end
+end
+

--- a/app/views/public/schedule/speakers.json.jbuilder
+++ b/app/views/public/schedule/speakers.json.jbuilder
@@ -14,6 +14,7 @@ json.schedule_speakers do
       json.id event.id
       json.title event.title
       json.logo event.logo_path
+      json.type event.event_type
     end
   end
 end


### PR DESCRIPTION
Improve the public events view:

* Include the event type in speakers.json
* Display un-scheduled (but confirmed) events in the "events" view - they were already displayed in the "speakers" view
* Render event pages for un-scheduled (but confirmed) events
* Add a JSON endpoint for the "events" view