### PR TITLE
Don't expose unconfirmed events

### DIFF
--- a/app/views/public/schedule/speaker.html.haml
+++ b/app/views/public/schedule/speaker.html.haml
@@ -22,6 +22,7 @@
   %table.list
     %tbody
       - @speaker.public_and_accepted_events_as_speaker_in(@conference).each do |event|
-        %tr
-          %td= image_box event.logo, :small
-          %td= link_to event.title, public_event_path(:id => event.id)
+        - if event.state == 'confirmed'
+          %tr
+            %td= image_box event.logo, :small
+            %td= link_to event.title, public_event_path(:id => event.id)

--- a/app/views/public/schedule/speakers.html.haml
+++ b/app/views/public/schedule/speakers.html.haml
@@ -14,4 +14,5 @@
         %td
           %ul
             - speaker.public_and_accepted_events_as_speaker_in(@conference).each do |event|
-              %li= link_to event.title, public_event_path(:id => event.id)
+              - if event.state == 'confirmed'
+                %li= link_to event.title, public_event_path(:id => event.id)

--- a/app/views/public/schedule/speakers.json.jbuilder
+++ b/app/views/public/schedule/speakers.json.jbuilder
@@ -11,9 +11,11 @@ json.schedule_speakers do
       json.title link.title
     end
     json.events person.public_and_accepted_events_as_speaker_in(@conference) do |event|
-      json.id event.id
-      json.title event.title
-      json.logo event.logo_path
+      if event.state == 'confirmed'
+        json.id event.id
+        json.title event.title
+        json.logo event.logo_path
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment the public/speakers and public/event views will show all of a speaker's unconfirmed events if the speaker has at least one confirmed event. This PR stops it doing that.
