### PR TITLE
Shorten slugs to usable length, fix #131

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ActiveRecord::Base
   include ActiveRecord::Transitions
+  include ActionView::Helpers::TextHelper
 
   before_create :generate_guid
 
@@ -202,15 +203,17 @@ class Event < ActiveRecord::Base
   end
 
   def slug
-    [ 
-      self.conference.acronym,
-      self.id,
-      self.language,
-      self.room.try(:name).try(:parameterize, "_"), 
-      self.start_time.strftime("%Y%m%d%H%M"), 
-      self.title.parameterize("_"), 
-      self.speakers.map{|p| p.full_public_name.parameterize("_")},
-    ].flatten.join("_-_")
+    truncate(
+      [ 
+        self.conference.acronym,
+        self.id,
+        self.title.parameterize("_")
+      ].flatten.join("-"),
+      escape: false,
+      length: 240,
+      separator: "_",
+      omission: ""
+    ).to_str
   end
 
   def static_url


### PR DESCRIPTION
This changes the public slug format from `31c3_-_6561_-_en_-_saal_1_-_201412271100_-_31c3_opening_event_-_erdgeist
_-_geraldine_de_bastion` to `31c3-6561-en-31C3_Opening_Event ` a format similar to the filenames published in the recent years, but without a language identifier.

The original language is already available in the schedule and can be appended if needed. Published recordings may contain other languages as translations so the original
language should be excluded from the slug.

It uses truncate from TextHelper to enforce a maximum length. This shouldn’t be an issue in general as event.title has the default string column limit of 255 chars, but strange conference acronyms may break that.

Calls to_str to get an unsafe string for HTML templates.