### PR TITLE
Gemfile.lock: update json to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     jquery-rails (1.0.19)
       railties (~> 3.0)
       thor (~> 0.14)
-    json (1.8.1)
+    json (1.8.2)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
     linecache19 (0.5.12)


### PR DESCRIPTION
json 1.8.2 adds support for Ruby 2.2.0, fixing the following error.

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby -r ./siteconf20150504-27677-1kcpi1y.rb extconf.rb
creating Makefile

make "DESTDIR=" clean
rm -f
rm -f generator.so  *.o  *.bak mkmf.log .*.time

make "DESTDIR="
gcc -I. -I/usr/include -I/usr/include/ruby/backward -I/usr/include -I. -DJSON_GENERATOR    -fPIC -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -mtune=generic -fPIC -O3 -Wall -O0 -ggdb -m64 -o generator.o -c generator.c
In file included from /usr/include/stdio.h:27:0,
                 from /usr/include/ruby/defines.h:26,
                 from /usr/include/ruby/ruby.h:29,
                 from /usr/include/ruby.h:33,
                 from ../fbuffer/fbuffer.h:5,
                 from generator.c:1:
/usr/include/features.h:328:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
Makefile:238: recipe for target 'generator.o' failed
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/daniel/.gem/ruby/gems/json-1.8.1 for inspection.
Results logged to /home/daniel/.gem/ruby/extensions/x86_64-linux/json-1.8.1/gem_make.out
An error occurred while installing json (1.8.1), and Bundler cannot continue.
Make sure that `gem install json -v '1.8.1'` succeeds before bundling.