### PR TITLE
Techrider

### DIFF
--- a/app/controllers/cfp/events_controller.rb
+++ b/app/controllers/cfp/events_controller.rb
@@ -106,7 +106,7 @@ class Cfp::EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :title, :subtitle, :event_type, :time_slots, :language, :abstract, :description, :logo, :track_id, :submission_note,
+      :title, :subtitle, :event_type, :time_slots, :language, :abstract, :description, :logo, :track_id, :submission_note, :tech_rider,
       event_attachments_attributes: %i(id title attachment public _destroy),
       links_attributes: %i(id title url _destroy)
     )

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -222,7 +222,7 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :id, :title, :subtitle, :event_type, :time_slots, :state, :start_time, :public, :language, :abstract, :description, :logo, :track_id, :room_id, :note, :submission_note, :do_not_record, :recording_license,
+      :id, :title, :subtitle, :event_type, :time_slots, :state, :start_time, :public, :language, :abstract, :description, :logo, :track_id, :room_id, :note, :submission_note, :do_not_record, :recording_license, :tech_rider,
       event_attachments_attributes: %i(id title attachment public _destroy),
       ticket_attributes: %i(id remote_ticket_id),
       links_attributes: %i(id title url _destroy),

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,6 +14,7 @@ class ReportsController < ApplicationController
     @report_type = params[:id]
     @events = []
     @search_count = 0
+    @extra_fields = []
 
     conference_events = @conference.events
     if params[:term]
@@ -43,6 +44,11 @@ class ReportsController < ApplicationController
       r = conference_events.joins(:event_people).where(event_people: { role_state: [:canceled, :declined, :idea, :offer, :unclear], event_role: [:moderator, :speaker] })
     when 'do_not_record_events'
       r = conference_events.where(:do_not_record => true)
+    when 'events_with_tech_rider'
+      r = conference_events
+            .scheduled
+            .where(Event.arel_table[:tech_rider].not_eq(""))
+      @extra_fields << :tech_rider
     end
 
     unless r.nil? or r.empty?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -226,6 +226,7 @@ class Event < ActiveRecord::Base
     self.start_time = nil
     self.state = ''
     self.note = ''
+    self.tech_rider = ''
     self
   end
 

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -29,7 +29,7 @@
     = f.input :submission_note, :input_html => {:rows => 2}, :hint => "visibiliy: admin and user; additional information."
   %fieldset.inputs
     %legend Additional Resources
-    = f.input :do_not_record, as: :inline_boolean, :hint => "Will this event be recorded?"
+    = f.input :tech_rider, :input_html => {:rows => 2}, :hint => "What is needed for this event?"
     = f.input :recording_license, hint: "Recording license for this talk"
     = dynamic_association :links, "Links", f
     = dynamic_association :event_attachments, "Uploaded files", f

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -120,3 +120,8 @@
       %p
         %b Submission Notes(user and admin):
         = @event.submission_note
+  .row
+    .span8
+      %p
+        %b Tech Rider(user and admin):
+        = @event.tech_rider

--- a/app/views/reports/_events_table.html.haml
+++ b/app/views/reports/_events_table.html.haml
@@ -8,12 +8,16 @@
         %th= sort_link @search, :event_type, :term => params[:term]
         %th= sort_link @search, :state, "State", :term => params[:term]
         %th= sort_link @search, :created_at, :term => params[:term]
+        - if @extra_fields.include?(:tech_rider)
+          %th Tech rider
       - else
         %th Title
         %th Track
         %th Event type
         %th State
         %th Created at
+        - if @extra_fields.include?(:tech_rider)
+          %th Tech rider
       %th
   %tbody
     - events.each do |event|
@@ -27,6 +31,8 @@
         %td= event.event_type
         %td= event.state
         %td= l(event.created_at.to_date)
+        - if @extra_fields.include?(:tech_rider)
+          %td= event.tech_rider
         %td.buttons
           = action_button "small", 'Show', event
           - if can? :manage, event

--- a/app/views/reports/_report_menu.html.haml
+++ b/app/views/reports/_report_menu.html.haml
@@ -11,6 +11,7 @@
   %li= link_to "events with speakers in a problematic state", report_on_events_path("events_with_unusual_state_speakers")
   %li= link_to "events with 'do not record' flag set", report_on_events_path("do_not_record_events")
   %li= link_to "list all lectures with non default timeslots", report_on_events_path('event_timeslot_deviation')
+  %li= link_to "list all scheduled events with tech riders", report_on_events_path('events_with_tech_rider')
 %p Query Speakers
 %ul
   %li= link_to "missing speakers for the next 4 hours", report_on_people_path("expected_speakers")

--- a/db/migrate/20150504151913_add_tech_rider_to_event.rb
+++ b/db/migrate/20150504151913_add_tech_rider_to_event.rb
@@ -1,0 +1,5 @@
+class AddTechRiderToEvent < ActiveRecord::Migration
+  def change
+    add_column :events, :tech_rider, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 20150920130550) do
     t.text     "resources"
     t.text     "target_audience_experience"
     t.text     "target_audience_experience_text"
+    t.text     "tech_rider"
   end
 
   add_index "events", ["conference_id"], name: "index_events_on_conference_id"


### PR DESCRIPTION
Techrider is a free-form field similar to `Notes` that's supposed to be used to specifiy resources that are needed for an event. Examples are: projector, PA, microphone, a bottle of champagne ...

This PR contains a migration, updated views and a special-purpose report for all events with a Techrider.