### PR TITLE
event: show subtitle in _table partial

### DIFF
--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -28,6 +28,8 @@
         %td 
           = link_to event.title, event
           %p.small
+            = event.subtitle
+          %p.small
             = by_speakers(event)
         - if @conference.is_ticket_server_enabled? 
           %td


### PR DESCRIPTION
Display the event subtitle in the event overview.