### PR TITLE
schedule: export 'do not record' flags in json output

### DIFF
--- a/app/views/public/schedule/events.json.jbuilder
+++ b/app/views/public/schedule/events.json.jbuilder
@@ -6,6 +6,7 @@ json.conference_events do
     json.title event.title
     json.logo event.logo_path
     json.type event.event_type
+    json.do_not_record event.do_not_record
     if event.start_time and event.room
       json.start_time event.start_time
       json.end_time event.end_time

--- a/app/views/public/schedule/index.json.jbuilder
+++ b/app/views/public/schedule/index.json.jbuilder
@@ -33,6 +33,7 @@ json.schedule do
               json.language event.language
               json.abstract event.abstract
               json.description event.description
+              json.do_not_record event.do_not_record
               json.persons event.speakers, :id, :full_public_name
               json.links event.links do |link|
                 json.url url_for(link.url)


### PR DESCRIPTION
Issue #126 requested the do_not_record flags of events to be exported in the
json output. This patch implements this.