### PR TITLE
RFC: Use Ransack for searches through web forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'pg', group: :postgresql
 gem 'sqlite3', group: :sqlite3
 
 gem 'acts_as_commentable'
-gem 'acts_as_indexed'
 gem 'barista'
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem 'cancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,6 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     acts_as_commentable (4.0.1)
-    acts_as_indexed (0.8.3)
     ansi (1.4.3)
     archive-tar-minitar (0.5.2)
     arel (3.0.3)
@@ -237,7 +236,6 @@ PLATFORMS
 
 DEPENDENCIES
   acts_as_commentable
-  acts_as_indexed
   barista
   bcrypt-ruby (~> 3.0.0)
   bullet

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -10,12 +10,8 @@ class ConferencesController < ApplicationController
   # GET /conferences
   # GET /conferences.xml
   def index
-    if params.has_key?(:term) and not params[:term].empty?
-      @search = Conference.with_query(params[:term]).search(params[:q])
-    else
-      @search = Conference.search(params[:q])
-    end
-    @conferences = @search.result.paginate page: params[:page]
+    result = search Conference, params
+    @conferences = result.paginate page: params[:page]
 
     respond_to do |format|
       format.html # index.html.erb
@@ -98,6 +94,21 @@ class ConferencesController < ApplicationController
       return "edit_#{test}"
     }
     return "edit"
+  end
+
+  def search(conferences, params)
+    if params.has_key?(:term) and not params[:term].empty?
+      term = params[:term]
+      sort = params[:q][:s] rescue nil
+      @search = events.ransack(title_cont: term,
+                               acronym_cont: term,
+                               m: 'or',
+                               s: sort)
+    else
+      @search = conferences.ransack(params[:q])
+    end
+
+    @search.result(distinct: true)
   end
 
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,12 +8,9 @@ class EventsController < ApplicationController
   # GET /events.xml
   def index
     authorize! :read, Event
-    if params.has_key?(:term) and not params[:term].empty?
-      @search = @conference.events.with_query(params[:term]).includes(:track).search(params[:q])
-    else
-      @search = @conference.events.includes(:track).search(params[:q])
-    end
-    @events = @search.result.paginate page: params[:page]
+
+    result = search @conference.events.includes(:track), params
+    @events = result.paginate page: params[:page]
 
     clean_events_attributes
     respond_to do |format|
@@ -25,13 +22,10 @@ class EventsController < ApplicationController
   # current_users events
   def my
     authorize! :read, Event
-    if params.has_key?(:term) and not params[:term].empty?
-      @search = @conference.events.associated_with(current_user.person).with_query(params[:term]).search(params[:q])
-    else
-      @search = @conference.events.associated_with(current_user.person).search(params[:q])
-    end
+
+    result = search @conference.events.associated_with(current_user.person), params
     clean_events_attributes
-    @events = @search.result.paginate page: params[:page]
+    @events = result.paginate page: params[:page]
   end
 
   # events as pdf
@@ -51,8 +45,9 @@ class EventsController < ApplicationController
   # show event ratings
   def ratings
     authorize! :create, EventRating
-    @search = @conference.events.search(params[:q])
-    @events = @search.result.paginate page: params[:page]
+
+    result = search @conference.events, params
+    @events = result.paginate page: params[:page]
     clean_events_attributes
 
     # total ratings:
@@ -68,8 +63,8 @@ class EventsController < ApplicationController
   # show event feedbacks
   def feedbacks
     authorize! :access, :event_feedback
-    @search = @conference.events.accepted.search(params[:q])
-    @events = @search.result.paginate page: params[:page]
+    result = search @conference.events.accepted, params
+    @events = result.paginate page: params[:page]
   end
 
   # start batch event review
@@ -221,6 +216,24 @@ class EventsController < ApplicationController
     unless @events.nil?
       @events.map { |event| event.clean_event_attributes! } 
     end
+  end
+
+  def search(events, params)
+    if params.has_key?(:term) and not params[:term].empty?
+      term = params[:term]
+      sort = params[:q][:s] rescue nil
+      @search = events.ransack(title_cont: term,
+                               description_cont: term,
+                               abstract_cont: term,
+                               track_name_cont: term,
+                               event_type_is: term,
+                               m: 'or',
+                               s: sort)
+    else
+      @search = events.ransack(params[:q])
+    end
+
+    @search.result(distinct: true)
   end
 
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -13,8 +13,6 @@ class Conference < ActiveRecord::Base
   has_one :call_for_papers, dependent: :destroy
   has_one :ticket_server, dependent: :destroy
 
-  acts_as_indexed fields: [:title, :acronym ]
-
   accepts_nested_attributes_for :rooms, reject_if: proc {|r| r["name"].blank?}, allow_destroy: true
   accepts_nested_attributes_for :days, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :tracks, reject_if: :all_blank, allow_destroy: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -48,8 +48,6 @@ class Event < ActiveRecord::Base
   scope :without_speaker, where("speaker_count = 0")
   scope :with_speaker, where("speaker_count > 0")
 
-  acts_as_indexed fields: [:title, :subtitle, :event_type, :abstract, :description, :track_name]
-
   has_paper_trail 
 
   state_machine do

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,8 +19,6 @@ class Person < ActiveRecord::Base
 
   belongs_to :user, dependent: :destroy
 
-  acts_as_indexed fields: [:first_name, :last_name, :public_name, :email, :abstract, :description, :user_email]
-
   has_paper_trail
 
   has_attached_file :avatar,


### PR DESCRIPTION
The results provided for web search requests require very strict matches as they go through acts_as_indexed. Ransack is already in the list of gems but only used when manual external requests are used with q= parameter assignment, using the Ransack query format.

Also, according to #107, acts_as_index causes index corruption.

To fix this, this PR implements a better way of searching by using Ransack with 'cond' predicates on the fields of events, people and conferences. In a 2nd step, acts_as_indexed is removed all together.