### PR TITLE
Warn about optout talks in generated schedule

### DIFF
--- a/app/views/public/schedule/event.html.haml
+++ b/app/views/public/schedule/event.html.haml
@@ -3,6 +3,9 @@
 
 .column.left#basic
   = image_box(@event.logo, :large)
+  - if @event.do_not_record
+    %p
+      %b #{t '.no_recording'}
   = simple_format @event.abstract, :class => "abstract"
   = simple_format @event.description, :class => "description"
 

--- a/config/locales/public.de.yml
+++ b/config/locales/public.de.yml
@@ -48,6 +48,7 @@ de:
         feedback: "Feedback"
         feedback_link: "Uns interessiert deine Meinung! Wie fandest du diese Veranstaltung?"
         speakers: "Referenten"
+        no_recording: "Diese Veranstaltung wird nicht aufgezeichnet"
 
       speaker:
         speaker: "Referent"

--- a/config/locales/public.en.yml
+++ b/config/locales/public.en.yml
@@ -48,6 +48,7 @@ en:
         feedback: "Feedback"
         feedback_link: "Click here to let us know how you liked this event."
         speakers: "Speakers"
+        no_recording: "This event is not going to be recorded"
 
       speaker:
         speaker: "Speaker"


### PR DESCRIPTION
Currently, the optout-flag is not presented to users except in the machine-readable schedule exports. This patch adds a warning to the generated HTML schedule if an event is not going to be recorded.