### PR TITLE
Add mass mail feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'bullet'
   gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     acts_as_commentable (4.0.2)
+    addressable (2.4.0)
     arel (6.0.3)
     bcrypt (3.1.10)
     bcrypt-ruby (3.1.5)
@@ -102,6 +103,10 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -243,6 +248,7 @@ DEPENDENCIES
   jquery-migrate-rails
   jquery-rails
   jquery-ui-rails
+  letter_opener
   localized_language_select!
   mysql2
   nokogiri

--- a/app/controllers/mail_templates_controller.rb
+++ b/app/controllers/mail_templates_controller.rb
@@ -1,0 +1,93 @@
+class MailTemplatesController < ApplicationController
+
+  before_filter :authenticate_user!
+  before_filter :not_submitter!
+  before_filter :find_conference
+
+  def new
+    @mail_template = MailTemplate.new
+  end
+
+  def edit
+    @mail_template = @conference.mail_templates.find(params[:id])
+  end
+
+  def show
+    @mail_template = @conference.mail_templates.find(params[:id])
+    @send_filter_options = [
+      [ "All speakers involved in all confirmed events",   :all_speakers_in_confirmed_events ],
+      [ "All speakers involved in all unconfirmed events", :all_speakers_in_unconfirmed_events ],
+    ]
+  end
+
+  def send_mail
+    @mail_template = @conference.mail_templates.find(params[:id])
+    send_filter = params[:send_filter]
+
+    if Rails.env.production?
+      @mail_template.send_async(send_filter)
+      redirect_to(@mail_template, notice: 'Mail deliveries queued.')
+    else
+      @mail_template.send_sync(send_filter)
+      redirect_to(@mail_template, notice: 'Mails delivered.')
+    end
+  end
+
+  def index
+    result = search @conference.mail_templates, params
+    @mail_templates = result.paginate page: params[:page]
+  end
+
+  def update
+    @mail_template = @conference.mail_templates.find(params[:id])
+
+    respond_to do |format|
+      if @mail_template.update_attributes(mail_template_params)
+        format.html { redirect_to(@mail_template, notice: 'Mail template was successfully updated.') }
+        format.xml  { head :ok }
+        format.js   { head :ok }
+      else
+        format.html { render action: "edit" }
+        format.xml  { render xml: @mail_template.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def create
+    t = MailTemplate.new(mail_template_params)
+    @conference.mail_templates << t
+    redirect_to(mail_templates_path, notice: 'Transport need was successfully added.')
+  end
+
+  def destroy
+    @conference.mail_templates.find(params[:id]).destroy
+    redirect_to(mail_templates_path, notice: 'Mail template was successfully destroyed.')
+  end
+
+  private
+
+  def find_conference
+    authorize! :administrate, @conference
+  end
+
+  def search(mail_templates, params)
+    if params.has_key?(:term) and not params[:term].empty?
+      term = params[:term]
+      sort = params[:q][:s] rescue nil
+      @search = mail_templates.ransack(name_cont: term,
+                                       subject_cont: term,
+                                       content_cont: term,
+                                       m: 'or',
+                                       s: sort)
+    else
+      @search = mail_templates.ransack(params[:q])
+    end
+
+    @search.result(distinct: true)
+  end
+
+  def mail_template_params
+    params.require(:mail_template).permit(:name, :subject, :content)
+  end
+
+end

--- a/app/jobs/send_bulk_mail_job.rb
+++ b/app/jobs/send_bulk_mail_job.rb
@@ -1,0 +1,30 @@
+class SendBulkMailJob
+  include SuckerPunch::Job
+
+  def perform(template, send_filter)
+    persons = Person
+                .joins(events: :conference)
+                .where(:'conferences.id' => template.conference.id)
+
+    case send_filter
+      when "all_speakers_in_confirmed_events"
+        persons = persons
+                    .where(:'events.state' => 'confirmed')
+                    .where(:'event_people.event_role' => 'speaker')
+
+      when "all_speakers_in_unconfirmed_events"
+        persons = persons
+                    .where(:'events.state' => 'unconfirmed')
+                    .where(:'event_people.event_role' => 'speaker')
+    end
+
+    persons = persons.group(:'people.id')
+
+    persons.each do |p|
+      UserMailer.bulk_mail(p, template).deliver_now
+      Rails.logger.info "Mail template #{template.name} delivered to #{p.first_name} #{p.last_name} (#{p.email})"
+    end
+  end
+
+end
+

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,4 +12,9 @@ class UserMailer < ActionMailer::Base
     @conference = conference
     mail to: @user.email, subject: I18n.t("mailers.user_mailer.confirmation_instructions")
   end
+
+  def bulk_mail(user, template)
+    mail to: user.email, subject: template.subject, body: template.content_for(user)
+  end
+
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -10,6 +10,7 @@ class Conference < ActiveRecord::Base
   has_many :rooms, dependent: :destroy
   has_many :tracks, dependent: :destroy
   has_many :conference_exports, dependent: :destroy
+  has_many :mail_templates, dependent: :destroy
   has_one :call_for_participation, dependent: :destroy
   has_one :ticket_server, dependent: :destroy
 

--- a/app/models/mail_template.rb
+++ b/app/models/mail_template.rb
@@ -1,0 +1,24 @@
+class MailTemplate < ActiveRecord::Base
+  belongs_to :conference
+  validates_presence_of :name
+  validates_presence_of :subject
+  validates_presence_of :content
+
+  def content_for(user)
+    content
+      .gsub('#first_name',  user.first_name)
+      .gsub('#last_name',   user.last_name)
+      .gsub('#public_name', user.public_name)
+  end
+
+  def send_sync(filter)
+    job = SendBulkMailJob.new
+    job.perform self, filter
+  end
+
+  def send_async(filter)
+    job = SendBulkMailJob.new
+    job.async.perform self, filter
+  end
+
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -40,6 +40,7 @@
               - if can? :manage, CallForParticipation
                 %li= link_to t("schedule", :default => "Schedule"), schedule_path
               - if can? :update, @conference
+                %li= link_to t("mail_templates", :default => "Mail templates"), mail_templates_path
                 %li= link_to t("settings", :default => "Settings"), edit_conference_path(@conference)
           %ul.nav.secondary-nav.pull-right
             - conferences = accessible_conferences

--- a/app/views/mail_templates/_form.html.haml
+++ b/app/views/mail_templates/_form.html.haml
@@ -1,0 +1,16 @@
+%p
+  The following place holders may be used in the
+  %code content
+  section of each template.
+  %ul
+    %li #first_name
+    %li #last_name
+    %li #public_name
+
+= simple_form_for @mail_template do |f|
+  %fieldset.inputs
+    = f.input :name
+    = f.input :subject, :input_html => { :size => 100 }
+    = f.input :content, as: :text, :input_html => { :rows => 20 }
+  .actions
+    = f.button :submit, class: 'primary'

--- a/app/views/mail_templates/_send_form.html.haml
+++ b/app/views/mail_templates/_send_form.html.haml
@@ -1,0 +1,9 @@
+%h2 Send mail
+%p
+  Use this mail template to send a mail to all people involved in
+  the events of this conference.
+
+= simple_form_for @mail_template, url: send_mail_mail_template_path, :html => { :method => :put } do |f|
+  .actions
+    = select_tag "send_filter", options_for_select(@send_filter_options), :style => "width:400px"
+    = f.button :submit, "Send", class: 'danger'

--- a/app/views/mail_templates/_table.html.haml
+++ b/app/views/mail_templates/_table.html.haml
@@ -1,0 +1,26 @@
+%table.zebra-stripe
+  %thead
+    %tr
+    - if @search
+      %th= sort_link @search, :name, 'Name', :term => params[:term]
+      %th= sort_link @search, :subject, 'Subject', :term => params[:term]
+      %th= sort_link @search, :content, 'Content', :term => params[:term]
+      %th= sort_link @search, :created_at, :term => params[:term]
+    - else
+      %th Name
+      %th Subject
+      %th Content
+      %th Created at
+    %th.last
+  %tbody
+    - collection.each do |t|
+      %tr
+        %td= link_to t.name, t
+        %td= t.subject
+        %td= t.content.truncate(100)
+        %td= t.created_at
+        %td.buttons
+          = action_button "small", 'Show', t
+          - if can? :crud, t
+            = action_button "small", 'Edit', edit_mail_template_path(t)
+            = action_button "small danger", 'Destroy', t, :confirm => 'Are you sure?', :method => :delete

--- a/app/views/mail_templates/edit.html.haml
+++ b/app/views/mail_templates/edit.html.haml
@@ -1,0 +1,6 @@
+%section
+  .page-header
+    %h1 Edit Mail template
+  .row
+    .span16
+      = render 'form'

--- a/app/views/mail_templates/index.html.haml
+++ b/app/views/mail_templates/index.html.haml
@@ -1,0 +1,7 @@
+%section
+  .page-header
+    .pull-right
+      - if can? :crud, MailTemplate
+        = action_button "primary", "Add mail template", new_mail_template_path, :hint => "Add a new mail template."
+    %h1 List of mail templates
+  = render 'shared/search_and_table', :collection => @mail_templates

--- a/app/views/mail_templates/new.html.haml
+++ b/app/views/mail_templates/new.html.haml
@@ -1,0 +1,5 @@
+= block do
+  = content do
+    %h2 New mail template
+    = inner do
+      = render 'form'

--- a/app/views/mail_templates/show.html.haml
+++ b/app/views/mail_templates/show.html.haml
@@ -1,0 +1,12 @@
+%section
+  .page-header
+    .pull-right
+      - if can? :crud, @mail_template
+        = action_button "primary", "Edit mail template", edit_mail_template_path(@mail_template), :hint => "Edit this mail template."
+    %h1 Mail template '#{@mail_template.name}'
+    %b Subject: #{@mail_template.subject}
+    %pre= @mail_template.content
+    %section
+      .row
+        .span16
+          =render 'send_form'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,6 +19,11 @@ Frab::Application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Use letter_opener for easier mail content testing in development
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+
+  config.action_mailer.delivery_method = :letter_opener
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/locales/frab.de.yml
+++ b/config/locales/frab.de.yml
@@ -26,6 +26,7 @@ de:
   rooms: "Räume"
   schedule: "Zeitplan"
   schedule_configuration: "Konfiguration des Zeitplans"
+  mail_templates: "Mailvorlagen"
   settings: "Einstellungen"
   sign_in_successful: "Erfolgreich eingeloggt."
   static_program_export: "Statischer Programm-Export"

--- a/config/locales/frab.en.yml
+++ b/config/locales/frab.en.yml
@@ -22,6 +22,7 @@ en:
   remove_association: "Remove %{name}"
   rooms: "Rooms"
   schedule: "Schedule"
+  mail_templates: "Mail Templates"
   settings: "Settings"
   sign_in_successful: "Successfully signed in."
   submission_configuration: "Submission Configuration"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,12 @@ Frab::Application.routes.draw do
         end
       end
 
+      resources :mail_templates do
+        member do
+          put :send_mail
+        end
+      end
+
     end # scope path: "/:conference_acronym"
 
     get "/:conference_acronym" => "home#index", as: "conference_home"

--- a/db/migrate/20150507211302_create_mail_templates.rb
+++ b/db/migrate/20150507211302_create_mail_templates.rb
@@ -1,0 +1,13 @@
+class CreateMailTemplates < ActiveRecord::Migration
+  def change
+    create_table :mail_templates do |t|
+      t.references :conference
+      t.string :name
+      t.string :subject
+      t.text :content
+
+      t.timestamps
+    end
+    add_index :mail_templates, :conference_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -160,47 +160,54 @@ ActiveRecord::Schema.define(version: 20150920130550) do
   add_index "event_ratings", ["person_id"], name: "index_event_ratings_on_person_id"
 
   create_table "events", force: :cascade do |t|
-    t.integer  "conference_id",                                                null: false
-    t.string   "title",                           limit: 255,                  null: false
-    t.string   "subtitle",                        limit: 255
-    t.string   "event_type",                      limit: 255, default: "talk"
+    t.integer  "conference_id",                                      null: false
+    t.string   "title",                 limit: 255,                  null: false
+    t.string   "subtitle",              limit: 255
+    t.string   "event_type",            limit: 255, default: "talk"
     t.integer  "time_slots"
-    t.string   "state",                           limit: 255, default: "new",  null: false
-    t.string   "language",                        limit: 255
+    t.string   "state",                 limit: 255, default: "new",  null: false
+    t.string   "language",              limit: 255
     t.datetime "start_time"
     t.text     "abstract"
     t.text     "description"
-    t.boolean  "public",                                      default: true
-    t.string   "logo_file_name",                  limit: 255
-    t.string   "logo_content_type",               limit: 255
+    t.boolean  "public",                            default: true
+    t.string   "logo_file_name",        limit: 255
+    t.string   "logo_content_type",     limit: 255
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
     t.integer  "track_id"
     t.integer  "room_id"
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.float    "average_rating"
-    t.integer  "event_ratings_count",                         default: 0
+    t.integer  "event_ratings_count",               default: 0
     t.text     "note"
     t.text     "submission_note"
-    t.integer  "speaker_count",                               default: 0
-    t.integer  "event_feedbacks_count",                       default: 0
+    t.integer  "speaker_count",                     default: 0
+    t.integer  "event_feedbacks_count",             default: 0
     t.float    "average_feedback"
-    t.string   "guid",                            limit: 255
-    t.boolean  "do_not_record",                               default: false
-    t.string   "recording_license",               limit: 255
-    t.integer  "number_of_repeats",                           default: 1
-    t.text     "other_locations"
-    t.text     "methods"
-    t.text     "resources"
-    t.text     "target_audience_experience"
-    t.text     "target_audience_experience_text"
+    t.string   "guid",                  limit: 255
+    t.boolean  "do_not_record",                     default: false
+    t.string   "recording_license",     limit: 255
+    t.text     "tech_rider"
   end
 
   add_index "events", ["conference_id"], name: "index_events_on_conference_id"
   add_index "events", ["event_type"], name: "index_events_on_type"
   add_index "events", ["guid"], name: "index_events_on_guid", unique: true
   add_index "events", ["state"], name: "index_events_on_state"
+
+  create_table "expenses", force: :cascade do |t|
+    t.string   "name",          limit: 255
+    t.decimal  "value"
+    t.boolean  "reimbursed"
+    t.integer  "person_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "conference_id"
+  end
+
+  add_index "expenses", ["person_id"], name: "index_expenses_on_person_id"
 
   create_table "im_accounts", force: :cascade do |t|
     t.integer  "person_id"
@@ -232,6 +239,17 @@ ActiveRecord::Schema.define(version: 20150920130550) do
   end
 
   add_index "links", ["linkable_id"], name: "index_links_on_linkable_id"
+
+  create_table "mail_templates", force: :cascade do |t|
+    t.integer  "conference_id"
+    t.string   "name",          limit: 255
+    t.string   "subject",       limit: 255
+    t.text     "content"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "mail_templates", ["conference_id"], name: "index_mail_templates_on_conference_id"
 
   create_table "notifications", force: :cascade do |t|
     t.datetime "created_at",                 null: false
@@ -281,10 +299,10 @@ ActiveRecord::Schema.define(version: 20150920130550) do
     t.integer  "conference_id",                            null: false
     t.string   "name",          limit: 255,                null: false
     t.integer  "size"
+    t.boolean  "public",                    default: true
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
     t.integer  "rank"
-    t.boolean  "public",                    default: true
   end
 
   add_index "rooms", ["conference_id"], name: "index_rooms_on_conference_id"
@@ -327,6 +345,20 @@ ActiveRecord::Schema.define(version: 20150920130550) do
   end
 
   add_index "tracks", ["conference_id"], name: "index_tracks_on_conference_id"
+
+  create_table "transport_needs", force: :cascade do |t|
+    t.integer  "person_id"
+    t.integer  "conference_id"
+    t.datetime "at"
+    t.integer  "seats"
+    t.boolean  "booked"
+    t.text     "note"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "transport_needs", ["conference_id"], name: "index_transport_needs_on_conference_id"
+  add_index "transport_needs", ["person_id"], name: "index_transport_needs_on_person_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                limit: 255, default: "",          null: false

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -198,4 +198,12 @@ FactoryGirl.define do
     event
     remote_ticket_id "1234"
   end
+
+  factory :mail_template do
+    conference
+    name "template one"
+    subject "subject one"
+    content "|first_name #first_name| |last_name #last_name| |public_name #public_name|"
+  end
+
 end

--- a/test/unit/mail_template_test.rb
+++ b/test/unit/mail_template_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class MailTemplateTest < ActiveSupport::TestCase
+
+  self.use_transactional_fixtures = false
+
+  setup do
+    ActionMailer::Base.deliveries = []
+    @event = create(:event, state: "confirmed")
+    @mail_template = create(:mail_template, conference: @event.conference)
+
+    @speaker = create(:person, include_in_mailings: true)
+    @speaker.first_name = "Frederick"
+    @speaker.last_name = "Besendorf"
+    @speaker.save
+
+    create(:event_person, event: @event, person: @speaker, event_role: "speaker", role_state: "confirmed")
+  end
+
+  test "speaker gets email" do
+    @mail_template.send_sync(:all_speakers_in_confirmed_events)
+    assert !ActionMailer::Base.deliveries.empty?
+  end
+
+  test "person gets no email if not not matching filter" do
+    @speaker.events = []
+    @mail_template.send_sync(:all_speakers_in_confirmed_events)
+    assert ActionMailer::Base.deliveries.empty?
+  end
+
+  test "mail content is personalized" do
+    @mail_template.send_sync(:all_speakers_in_confirmed_events)
+    m = ActionMailer::Base.deliveries.first
+    assert m.subject == @mail_template.subject
+    assert m.body.include? "|first_name #{@speaker.first_name}|"
+    assert m.body.include? "|last_name #{@speaker.last_name}|"
+    assert m.body.include? "|public_name #{@speaker.public_name}|"
+  end
+end


### PR DESCRIPTION
This pull request implements a simple mass mail feature that we used during a conference to contact confirmed speakers with latest updates. The filter mechanism that controls the list of receivers is easily extendable. It also includes a simple template engine that allows a bit of mail content personification.