### PR TITLE
Add schema.org JSON-LD metadata to schedule events.

### DIFF
--- a/app/views/public/schedule/event.html.haml
+++ b/app/views/public/schedule/event.html.haml
@@ -68,3 +68,31 @@
     %video{ class: 'video', controls: "controls" }
       %source{ type: @event.videos.first.mimetype, src: @event.videos.first.url }
 
+%script{:type => "application/ld+json"}
+  - performers = @event.speakers.map { |speaker| { :name => speaker.full_public_name, :@type => "Person", :sameAs => public_speaker_path(:id => speaker.id), :image => image_path(speaker.avatar.url(:small)) } }
+  :plain
+    {
+      "@context" : "http://schema.org",
+      "@type" : "Event",
+      "name" : "#{@event.title}",
+      "location" : {
+        "@type" : "Place",
+        "name" : "#{@event.room.try(:name)}",
+        "address" : "#{@conference.title}"
+      },
+      "startDate" : "#{@event.start_time.strftime("%F")}T#{@event.start_time.strftime("%T%z")}",
+      "endDate" : "#{@event.end_time.strftime("%F")}T#{@event.end_time.strftime("%T%z")}",
+      "performer" : #{performers.to_json},
+      "inLanguage" : "#{@event.language}",
+      "superEvent" : {
+        "@type" : "Event",
+        "sameAs" : "#{public_schedule_index_path}",
+        "name" : "#{@conference.title}",
+        "location" : {
+          "@type" : "Place",
+          "name" : "#{@conference.title}",
+          "address" : "#{@conference.title}"
+        },
+        "startDate" : "#{@conference.first_day.start_date.strftime("%F")}T#{@conference.first_day.start_date.strftime("%T%z")}"
+      }
+    }

--- a/app/views/public/schedule/index.html.haml
+++ b/app/views/public/schedule/index.html.haml
@@ -15,3 +15,18 @@
   %li= link_to "xCal", public_schedule_index_path(:format => :xcal)
   %li= link_to "XML", public_schedule_index_path(:format => :xml)
   %li= link_to("JSON", public_schedule_index_path(:format => :json)) + " (" + link_to(t('.speakers'), public_speakers_path(:format => :json)) + ")"
+
+%script{:type => "application/ld+json"}
+  :plain
+    {
+      "@context" : "http://schema.org",
+      "@type" : "Event",
+      "name" : "#{@conference.title}",
+      "location" : {
+        "@type" : "Place",
+        "name" : "#{@conference.title}",
+        "address" : "#{@conference.title}"
+      },
+      "startDate" : "#{@conference.first_day.start_date.strftime("%F")}T#{@conference.first_day.start_date.strftime("%T%z")}",
+      "endDate" : "#{@conference.first_day.end_date.strftime("%F")}T#{@conference.first_day.end_date.strftime("%T%z")}"
+    }


### PR DESCRIPTION
This allows modern search engines and other consumers of schema.org
metadata to better understand conferences organized with frab.

The resulting metadata was successfully verified using
https://developers.google.com/structured-data/testing-tool/
