### PR TITLE
Fix configuring ActionMailer from environment variables

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -3,10 +3,8 @@ ActionMailer::Base.default_url_options = {
   protocol: ENV.fetch('FRAB_PROTOCOL')
 }
 if ENV["SMTP_ADDRESS"]
-  smtp_settings = {}
   %w(ADDRESS PORT DOMAIN USER_NAME PASSWORD).each do |setting|
     next unless ENV["SMTP_#{setting}"]
-    smtp_settings[setting.downcase] = ENV["SMTP_#{setting}"]
+    ActionMailer::Base.smtp_settings[:"#{setting.downcase}"] = ENV["SMTP_#{setting}"]
   end
-  ActionMailer::Base.smtp_settings = smtp_settings
 end


### PR DESCRIPTION
The email settings i entered in `.env.production` seemed to be ignored, so I started a little investigation. I came up with these changes:

1. Use symbols as keys when populating ActionMailer::Base.smtp_settings (fixes the bug)
2. Only replace default settings we have new values for (seemed like the right thing to do)

Please note that I'm not familiar with Ruby and have no idea what I'm doing. But this seems to do the trick.