### PR TITLE
nil guard for date localization

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,10 @@ module ApplicationHelper
     image_tag "icons/#{name}.png"
   end
 
+  def ldate(date, options = {})
+    [Date, DateTime, Time].include?(date.class) ? l(date, options) : t(:date_not_set)
+  end
+
   def action_button(button_type, link_name, path, options = {})
     options[:class] = "btn #{button_type}"
     if options[:hint]

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -7,11 +7,6 @@ module EventsHelper
     end
   end
 
-  def event_start_time
-    return '' unless @event.start_time
-    I18n.l(@event.start_time, format: :pretty_datetime)
-  end
-
   def timeslots
     slots = []
     (@conference.max_timeslots + 1).times do |i|

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -17,7 +17,7 @@
     = f.input :state, :collection => Event.state_machine.states.map { |st| [st.display_name, st.name.to_s] }
   %fieldset.inputs
     %legend Time and place
-    = f.input :start_time, collection: @conference.days, as: :grouped_select, group_method: :start_times, selected: event_start_time
+    = f.input :start_time, collection: @conference.days, as: :grouped_select, group_method: :start_times, selected: ldate(@event.start_time, format: :pretty_datetime)
     = f.association :room
   %fieldset.inputs
     %legend Detailed description

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -73,7 +73,7 @@
       - if can? :crud, Event
         %p
           %b Start time:
-          = l(@event.start_time, format: :pretty_datetime)
+          = ldate(@event.start_time, format: :pretty_datetime)
       %p
         %b Room:
         = @event.room.try(:name)

--- a/config/locales/frab.de.yml
+++ b/config/locales/frab.de.yml
@@ -6,6 +6,7 @@ de:
   create_new_conference: "Neue Konferenz erstellen"
   create_your_first_conference: "Erste Konferenz erstellen"
   days: "Tage"
+  date_not_set: "noch nicht gesetzt"
   edit: "Bearbeiten"
   edit_conference: "Konferenz bearbeiten"
   edit_conference_days: "Konferenz-Tage bearbeiten"

--- a/config/locales/frab.en.yml
+++ b/config/locales/frab.en.yml
@@ -6,6 +6,7 @@ en:
   create_new_conference: "Create new conference"
   create_your_first_conference: "Create your first conference"
   days: "Days"
+  date_not_set: "Date not set yet"
   edit: "edit"
   edit_conference: "Edit conference"
   edit_conference_days: "Edit conference days"


### PR DESCRIPTION
This implement a nil guard for date localization on ApplicationHelper#ldate(date, options) which will return a translated t(:date_not_set) is date is nil.

It's currently used on Event views to make them resistant to application failure if trying to be rendered with start_time attribute being nil (as in not set yet) for the event.