### PR TITLE
Add new entry "dect" to PhoneNumber::TYPES

### DIFF
--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,5 +1,5 @@
 class PhoneNumber < ActiveRecord::Base
-  TYPES = %w(fax mobile phone private secretary skype work)
+  TYPES = %w(fax mobile phone private secretary skype work dect)
 
   belongs_to :person
 

--- a/config/locales/frab.de.yml
+++ b/config/locales/frab.de.yml
@@ -47,6 +47,7 @@ de:
   options:
     business: "Geschäftlich"
     concert: "Konzert"
+    dect: "DECT"
     djset: "DJ-Set"
     fax: "Fax"
     female: "weiblich"

--- a/config/locales/frab.en.yml
+++ b/config/locales/frab.en.yml
@@ -41,6 +41,7 @@ en:
   options:
     business: "business"
     concert: "concert"
+    dect: "DECT"
     djset: "DJ set"
     fax: "fax"
     female: "female"


### PR DESCRIPTION
It would be useful to be able to list a speaker's DECT (or generically: event internal phone network) number with the person's entry.

(This was something we noticed at Chaos Communication Camp 2015: Due to bad weather some last-minute scheduling work was necessary, but we couldn't locate speakers on the camp ground and wouldn't be sure that an e-mail would be received in time. At least for CCC events most people have an internal DECT or GSM number anyway, so it would be good to be able to record that.)