### PR TITLE
TransportNeeds

### DIFF
--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -116,6 +116,7 @@ table.room tr.even {background: #EEEEEE;}
 span.right { float: right; }
 
 td.buttons { white-space: nowrap; }
+td.nowrap { white-space: nowrap; }
 
 a.assoc {
   margin-left: 150px;

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -124,9 +124,9 @@ class ConferencesController < ApplicationController
 
   def conference_params
     params.require(:conference).permit(
-      :acronym, :title, :timezone, :timeslot_duration, :default_timeslots, :max_timeslots, :feedback_enabled, :expenses_enabled, :email,
-      :program_export_base_url, :schedule_version, :schedule_public, :color, :ticket_type, :event_state_visible, :schedule_custom_css,
-      :schedule_html_intro, :default_recording_license,
+      :acronym, :title, :timezone, :timeslot_duration, :default_timeslots, :max_timeslots, :feedback_enabled, :expenses_enabled,
+      :transport_needs_enabled, :email, :program_export_base_url, :schedule_version, :schedule_public, :color, :ticket_type,
+      :event_state_visible, :schedule_custom_css, :schedule_html_intro, :default_recording_license,
       rooms_attributes: %i(name size public rank _destroy id),
       days_attributes: %i(start_date end_date _destroy id),
       tracks_attributes: %i(name color _destroy id),

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -124,7 +124,9 @@ class ConferencesController < ApplicationController
 
   def conference_params
     params.require(:conference).permit(
-      :acronym, :title, :timezone, :timeslot_duration, :default_timeslots, :max_timeslots, :feedback_enabled, :email, :program_export_base_url, :schedule_version, :schedule_public, :color, :ticket_type, :event_state_visible, :schedule_custom_css, :schedule_html_intro, :default_recording_license,
+      :acronym, :title, :timezone, :timeslot_duration, :default_timeslots, :max_timeslots, :feedback_enabled, :expenses_enabled, :email,
+      :program_export_base_url, :schedule_version, :schedule_public, :color, :ticket_type, :event_state_visible, :schedule_custom_css,
+      :schedule_html_intro, :default_recording_license,
       rooms_attributes: %i(name size public rank _destroy id),
       days_attributes: %i(start_date end_date _destroy id),
       tracks_attributes: %i(name color _destroy id),

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -2,6 +2,7 @@ class ExpensesController < ApplicationController
   before_filter :authenticate_user!
   before_filter :not_submitter!
   before_filter :find_person
+  before_filter :check_enabled
 
   def new
     @expense = Expense.new
@@ -41,6 +42,12 @@ class ExpensesController < ApplicationController
   def find_person
     @person = Person.find(params[:person_id])
     authorize! :administrate, @person
+  end
+
+  def check_enabled
+    unless @conference.expenses_enabled?
+      redirect_to(person_url(@person), notice: 'Expenses are not enabled for this conference')
+    end
   end
 
   def expenses_params

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -55,6 +55,8 @@ class PeopleController < ApplicationController
     @expenses_sum_reimbursed = @person.sum_of_expenses(@conference, true)
     @expenses_sum_non_reimbursed = @person.sum_of_expenses(@conference, false)
 
+    @transport_needs = @person.transport_needs.where(:conference_id => @conference.id)
+
     respond_to do |format|
       format.html
       format.xml { render xml: @person }

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -178,4 +178,15 @@ class ReportsController < ApplicationController
       format.html { render :show }
     end
   end
+
+  def show_transport_needs
+    authorize! :manage, CallForParticipation
+
+    @search = @conference.transport_needs.search(params[:q])
+    @transport_needs = @search.result
+    @report_type = params[:id]
+
+    render :show
+  end
+
 end

--- a/app/controllers/transport_needs_controller.rb
+++ b/app/controllers/transport_needs_controller.rb
@@ -1,0 +1,56 @@
+class TransportNeedsController < ApplicationController
+
+  before_filter :authenticate_user!
+  before_filter :not_submitter!
+  before_filter :find_person
+  before_filter :check_enabled
+
+  def new
+    @transport_need = TransportNeed.new
+    @transport_need.seats = 1
+  end
+
+  def edit
+    @transport_need = @person.transport_needs.find(params[:id])
+  end
+
+  def index
+    @transport_needs = @person.transport_needs.where(:conference_id => @conference.id)
+  end
+
+  def update
+    transport_need = @person.transport_needs.find(params[:id])
+    transport_need.update_attributes(transport_needs_params)
+    redirect_to(person_url(@person), notice: 'Transport need was successfully updated.')
+  end
+
+  def create
+    tn = TransportNeed.new(transport_needs_params)
+    tn.conference = @conference
+    @person.transport_needs << tn
+    redirect_to(person_url(@person), notice: 'Transport need was successfully added.')
+  end
+
+  def destroy
+    @person.transport_needs.find(params[:id]).destroy
+    redirect_to(person_url(@person), notice: 'Transport need was successfully destroyed.')
+  end
+
+  private
+
+  def find_person
+    @person = Person.find(params[:person_id])
+    authorize! :administrate, @person
+  end
+
+  def check_enabled
+    unless @conference.transport_needs_enabled?
+      redirect_to(person_url(@person), notice: 'Transport needs are not enabled for this conference')
+    end
+  end
+
+  def transport_needs_params
+    params.require(:transport_need).permit(:at, :transport_type, :seats, :booked, :note)
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,6 +73,12 @@ module ApplicationHelper
     result
   end
 
+  def t_boolean(b)
+    b ?
+      t("simple_form.yes") :
+      t("simple_form.no")
+  end
+
   def available_conference_locales
     conference_locales = @conference.language_codes.map(&:to_sym)
     I18n.available_locales & conference_locales

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -28,6 +28,7 @@ class Conference < ActiveRecord::Base
     :timeslot_duration,
     :timezone
   validates_inclusion_of :feedback_enabled, in: [true, false]
+  validates_inclusion_of :expenses_enabled, in: [true, false]
   validates_uniqueness_of :acronym
   validates_format_of :acronym, with: /\A[a-zA-Z0-9_-]*\z/
   validate :days_do_not_overlap

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -11,6 +11,7 @@ class Conference < ActiveRecord::Base
   has_many :tracks, dependent: :destroy
   has_many :conference_exports, dependent: :destroy
   has_many :mail_templates, dependent: :destroy
+  has_many :transport_needs, dependent: :destroy
   has_one :call_for_participation, dependent: :destroy
   has_one :ticket_server, dependent: :destroy
 
@@ -29,6 +30,7 @@ class Conference < ActiveRecord::Base
     :timezone
   validates_inclusion_of :feedback_enabled, in: [true, false]
   validates_inclusion_of :expenses_enabled, in: [true, false]
+  validates_inclusion_of :transport_needs_enabled, in: [true, false]
   validates_uniqueness_of :acronym
   validates_format_of :acronym, with: /\A[a-zA-Z0-9_-]*\z/
   validate :days_do_not_overlap

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -10,6 +10,7 @@ class Person < ActiveRecord::Base
   has_many :links, as: :linkable, dependent: :destroy
   has_many :phone_numbers, dependent: :destroy
   has_many :expenses, dependent: :destroy
+  has_many :transport_needs, dependent: :destroy
 
   accepts_nested_attributes_for :availabilities, reject_if: :all_blank
   accepts_nested_attributes_for :im_accounts, reject_if: :all_blank, allow_destroy: true

--- a/app/models/transport_need.rb
+++ b/app/models/transport_need.rb
@@ -1,0 +1,9 @@
+class TransportNeed < ActiveRecord::Base
+  belongs_to :person
+  belongs_to :conference
+  validates_presence_of :at
+
+  TYPES = %w(bus, shuttle)
+
+  default_scope { order('at ASC') }
+end

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -17,8 +17,9 @@
     = f.input :event_state_visible, as: :inline_boolean, hint: "If you enable this, speakers will be able to look up the state of their submission in the cfp interface and confirm their attendance by pressing the confirm button."
     = f.input :default_recording_license, hint: "Default recording license for all talks"
   %fieldset.inputs
-    %legend= t(:feedback_system)
+    %legend= t(:features)
     = f.input :feedback_enabled, as: :inline_boolean, hint: "If you enable this, your program export will include links to a feedback form where attendees can rate an event."
+    = f.input :expenses_enabled, as: :inline_boolean, hint: "If you enable this, frab will allow you to track expenses of people"
   %fieldset.inputs
     %legend= t(:ticket_server)
     = f.input :ticket_type, as: :radio_buttons, collection: Conference::TICKET_TYPES

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -20,6 +20,7 @@
     %legend= t(:features)
     = f.input :feedback_enabled, as: :inline_boolean, hint: "If you enable this, your program export will include links to a feedback form where attendees can rate an event."
     = f.input :expenses_enabled, as: :inline_boolean, hint: "If you enable this, frab will allow you to track expenses of people"
+    = f.input :transport_needs_enabled, as: :inline_boolean, hint: "If you enable this, frab will allow you to track transportation needs of people"
   %fieldset.inputs
     %legend= t(:ticket_server)
     = f.input :ticket_type, as: :radio_buttons, collection: Conference::TICKET_TYPES

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -116,3 +116,26 @@
       .span10
         %p
           = to_currency @expenses_sum_non_reimbursed
+
+- if @conference.transport_needs_enabled? and @transport_needs.any?
+  %section
+    .row
+      .span16
+        %h2 Transport needs
+        %table.zebra-striped
+          %thead
+            %tr
+              %th When
+              %th Type
+              %th # of seats
+              %th Booked?
+              %th Note
+              %th
+          %tbody
+            - @transport_needs.each do |tn|
+              %tr
+                %td= tn.at.to_formatted_s(:long)
+                %td= tn.transport_type
+                %td= tn.seats
+                %td= tn.booked
+                %td= tn.note

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -97,7 +97,7 @@
         %h2 Events in other conferences
         = render "events_in_other_conferences_table", collection: @other_events
 
-- if @expenses.any?
+- if @conference.expenses_enabled? and @expenses.any?
   %section
     .row
       .span16

--- a/app/views/reports/_report_menu.html.haml
+++ b/app/views/reports/_report_menu.html.haml
@@ -20,7 +20,8 @@
   %li= link_to "confirmed people speaking at conference", report_on_people_path("people_speaking_at")
   %li= link_to "people with a note in their submission", report_on_people_path("people_with_a_note")
   %li= link_to "people with more than one submission", report_on_people_path("people_with_more_than_one")
-  %li= link_to "people with non-reimbursed expenses", report_on_people_path("people_with_non_reimbursed_expenses")
+  - if @conference.expenses_enabled?
+    %li= link_to "people with non-reimbursed expenses", report_on_people_path("people_with_non_reimbursed_expenses")
 %p Statistics
 %ul
   %li= link_to "used timeslots (hours)", report_on_statistics_path("event_timeslot_sum")

--- a/app/views/reports/_report_menu.html.haml
+++ b/app/views/reports/_report_menu.html.haml
@@ -28,3 +28,8 @@
   %li= link_to "confirmed event numbers by track", report_on_statistics_path("confirmed_events_by_track")
   %li= link_to "event numbers by track", report_on_statistics_path("events_by_track")
   %li= link_to "confirmed speakers by day with attendance status", report_on_statistics_path("people_speaking_by_day")
+
+- if @conference.transport_needs_enabled?
+  %p Transport needs
+  %ul
+    %li= link_to "overview on transport needs", report_on_transport_needs_path("all")

--- a/app/views/reports/_transport_needs_table.html.haml
+++ b/app/views/reports/_transport_needs_table.html.haml
@@ -1,0 +1,29 @@
+%table.zebra-stripe
+  %thead
+    %tr
+      %th.first
+      - if @search
+        %th= sort_link @search, :name, :term => params[:term]
+        %th= sort_link @search, :at, :term => params[:term]
+        %th= sort_link @search, :transport_type, :term => params[:term]
+        %th= sort_link @search, :seats, :term => params[:term]
+        %th= sort_link @search, :booked, :term => params[:term]
+        %th= sort_link @search, :note, :term => params[:term]
+      - else
+        %th Name
+        %th When
+        %th Type
+        %th # of seats
+        %th Booked
+        %th Note
+      %th.last
+  %tbody
+    - transport_needs.each do |tn|
+      %tr
+        %td= link_to (image_box tn.person.avatar, :small), tn.person
+        %td= link_to tn.person.full_name, tn.person
+        %td= tn.at.to_formatted_s(:long)
+        %td= tn.transport_type
+        %td= tn.seats
+        %td= t_boolean(tn.booked)
+        %td= tn.note

--- a/app/views/reports/show.html.haml
+++ b/app/views/reports/show.html.haml
@@ -31,3 +31,7 @@
     .row
       .span16
         = render 'statistics_table', data: @data
+  - if not @transport_needs.nil? and not @transport_needs.empty?
+    .row
+      .span16
+        = render 'transport_needs_table', transport_needs: @transport_needs

--- a/app/views/shared/_people_tabs.html.haml
+++ b/app/views/shared/_people_tabs.html.haml
@@ -12,4 +12,6 @@
       %li{class: active_class?(edit_person_availability_path(@person))}= link_to "Availability", edit_person_availability_path(@person)
   -if @conference.expenses_enabled? and can? :administrate, User
     %li{class: active_class?(person_expenses_path(@person))}= link_to "Expenses", person_expenses_path(@person)
+  -if @conference.transport_needs_enabled? and can? :administrate, User
+    %li{class: active_class?(person_transport_needs_path(@person))}= link_to "Transport needs", person_transport_needs_path(@person)
   %li{class: active_class?(feedbacks_people_path)}= link_to "Feedback", feedbacks_people_path(id: @person.id)

--- a/app/views/shared/_people_tabs.html.haml
+++ b/app/views/shared/_people_tabs.html.haml
@@ -10,6 +10,6 @@
       %li{class: active_class?(new_person_availability_path(@person))}= link_to "Availability", new_person_availability_path(@person)
     - else
       %li{class: active_class?(edit_person_availability_path(@person))}= link_to "Availability", edit_person_availability_path(@person)
-  - if can? :administrate, User
+  -if @conference.expenses_enabled? and can? :administrate, User
     %li{class: active_class?(person_expenses_path(@person))}= link_to "Expenses", person_expenses_path(@person)
   %li{class: active_class?(feedbacks_people_path)}= link_to "Feedback", feedbacks_people_path(id: @person.id)

--- a/app/views/shared/_transport_needs_form.html.haml
+++ b/app/views/shared/_transport_needs_form.html.haml
@@ -1,0 +1,18 @@
+= simple_form_for [person, transport_need] do |f|
+  %fieldset.inputs
+    = f.input :at, html5: true, as: :datetime, hint: "yyyy-mm-dd hh:mm"
+    = f.input :transport_type, as: :select, collection: TransportNeed::TYPES, hint: "What type of transportation is needed?"
+    = f.input :seats, hint: "How many seats are needed?"
+    = f.input :booked, as: :inline_boolean, hint: "Has this transportation been booked?"
+    = f.input :note
+  .actions
+    - if can? :administrate, person
+      = f.button :submit, class: 'primary'
+
+:javascript
+  $(function() {
+    $('div.datetime input').datetimepicker({
+        dateFormat: "yy-mm-dd",
+        timeFormat: "hh:mm"
+    });
+  })

--- a/app/views/transport_needs/edit.html.haml
+++ b/app/views/transport_needs/edit.html.haml
@@ -1,0 +1,8 @@
+%section
+  .page-header
+    .pull-right
+    %h1 Person: #{@person.full_name}
+  = render 'shared/people_tabs'
+  .row
+    .span16
+      = render(:partial => 'shared/transport_needs_form', :locals => { :person => @person, :transport_need => @transport_need, :url => person_transport_needs_path })

--- a/app/views/transport_needs/index.html.haml
+++ b/app/views/transport_needs/index.html.haml
@@ -1,0 +1,29 @@
+%section
+  .page-header
+    .pull-right
+    %h1 Person: #{@person.full_name}
+  = render 'shared/people_tabs'
+
+  - if @transport_needs.any?
+    %table.zebra-striped
+      %thead
+        %tr
+          %th When
+          %th Type
+          %th # of seats
+          %th Booked?
+          %th Note
+          %th
+      %tbody
+        - @transport_needs.each do |tn|
+          %tr
+            %td= tn.at.to_formatted_s(:long)
+            %td= tn.transport_type
+            %td= tn.seats
+            %td= t_boolean(tn.booked)
+            %td= tn.note
+            %td
+              =action_button "small", 'Edit', edit_person_transport_need_path(@person, tn)
+              =action_button "small danger", 'Destroy', person_transport_need_path(@person, tn), :confirm => 'Are you sure?', :method => :delete
+
+  =action_button "small", 'New transport need', new_person_transport_need_path

--- a/app/views/transport_needs/new.html.haml
+++ b/app/views/transport_needs/new.html.haml
@@ -1,0 +1,10 @@
+%section
+  .page-header
+    .pull-right
+    %h1 Person: #{@person.full_name}
+  = render 'shared/people_tabs'
+  .row
+    .span16
+      = content do
+        = inner do
+          = render(:partial => 'shared/transport_needs_form', :locals => { :person => @person, :conference => @conference, :transport_need => @transport_need, :url => person_transport_needs_path })

--- a/config/locales/frab.de.yml
+++ b/config/locales/frab.de.yml
@@ -17,7 +17,7 @@ de:
   error_signing_in: "E-Mailadresse oder Passwort ungültig."
   event_languages: "Veranstaltungssprachen"
   events: "Veranstaltungen"
-  feedback_system: "Feedback-System"
+  features: "Zusatzfunktionen"
   launch_call_for_participation: "Call for Participation starten"
   new_conference: "Neue Konferenz"
   people: "Personen"
@@ -76,7 +76,7 @@ de:
       short_datetime: '%d. %H:%M'
       time: '%H:%M'
     time_range_seperator: ' bis '
-      
+
   date:
     formats:
       only_day: "%e"
@@ -132,9 +132,9 @@ de:
         precision: 1
       decimal_units:
         units:
-          billion: 
+          billion:
             others: Milliarden
-          quadrillion: 
+          quadrillion:
             others: Billiarden
 
   support:
@@ -155,7 +155,7 @@ de:
       too_long: "ist zu lang (nicht mehr als %{count} Zeichen)"
       too_short: "ist zu kurz (nicht weniger als %{count} Zeichen)"
       wrong_length: "hat die falsche Länge (muss genau %{count} Zeichen haben)"
-      
+
   activerecord:
     errors:
       template:
@@ -164,7 +164,7 @@ de:
           other:  "Konnte %{model} nicht speichern: %{count} Fehler."
         body: "Bitte überprüfen Sie die folgenden Felder:"
 
-      messages:        
+      messages:
         taken: "ist bereits vergeben"
         record_invalid: "Gültigkeitsprüfung ist fehlgeschlagen: %{errors}"
         <<: *errors_messages

--- a/config/locales/frab.en.yml
+++ b/config/locales/frab.en.yml
@@ -16,7 +16,7 @@ en:
   edit_ticket_server: "Edit ticket server"
   error_signing_in: "Invalid email or password."
   event_languages: "Event languages"
-  feedback_system: "Feedback System"
+  features: "Additional features"
   new_conference: "New conference"
   notifications: Notifications
   remove_association: "Remove %{name}"

--- a/config/locales/frab.pt-BR.yml
+++ b/config/locales/frab.pt-BR.yml
@@ -15,7 +15,7 @@ pt-BR:
   error_signing_in: "E-mail ou senha inválidos."
   event_languages: "Línguagens do evento"
   events: "Eventos"
-  feedback_system: "Sistema de Feedback"
+  features: "Otras opciónes"
   launch_call_for_participation: "Iniciar Chamada de Trabalhos"
   new_conference: "Nova conferência"
   people: "Pessoas"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Frab::Application.routes.draw do
         resource :user
         resource :availability
         resources :expenses
+        resources :transport_needs
         collection do
           get :all
           get :feedbacks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Frab::Application.routes.draw do
       get '/reports/on_people/:id' => 'reports#show_people', as: 'report_on_people'
       get '/reports/on_events/:id' => 'reports#show_events', as: 'report_on_events'
       get '/reports/on_statistics/:id' => 'reports#show_statistics', as: 'report_on_statistics'
+      get "/reports/on_transport_needs/:id" => "reports#show_transport_needs", as: "report_on_transport_needs"
 
       resources :tickets do
         member do

--- a/db/migrate/20150505140202_create_transport_needs.rb
+++ b/db/migrate/20150505140202_create_transport_needs.rb
@@ -1,0 +1,17 @@
+class CreateTransportNeeds < ActiveRecord::Migration
+  def change
+    create_table :transport_needs do |t|
+      t.references :person
+      t.references :conference
+      t.datetime :at
+      t.string :transport_type
+      t.integer :seats
+      t.boolean :booked
+      t.text :note
+
+      t.timestamps
+    end
+    add_index :transport_needs, :person_id
+    add_index :transport_needs, :conference_id
+  end
+end

--- a/db/migrate/20160221162627_add_more_settings_to_conference.rb
+++ b/db/migrate/20160221162627_add_more_settings_to_conference.rb
@@ -1,0 +1,6 @@
+class AddMoreSettingsToConference < ActiveRecord::Migration
+  def change
+    add_column :conferences, :expenses_enabled, :boolean, default: false, null: false
+    add_column :conferences, :transport_needs_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150920130550) do
+ActiveRecord::Schema.define(version: 20160221162627) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer  "person_id"
@@ -84,6 +84,8 @@ ActiveRecord::Schema.define(version: 20150920130550) do
     t.text     "schedule_custom_css",       limit: 2097152
     t.text     "schedule_html_intro",       limit: 2097152
     t.string   "default_recording_license", limit: 255
+    t.boolean  "expenses_enabled",                          default: false,        null: false
+    t.boolean  "transport_needs_enabled",                   default: false,        null: false
   end
 
   add_index "conferences", ["acronym"], name: "index_conferences_on_acronym"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,41 +162,35 @@ ActiveRecord::Schema.define(version: 20160221162627) do
   add_index "event_ratings", ["person_id"], name: "index_event_ratings_on_person_id"
 
   create_table "events", force: :cascade do |t|
-    t.integer  "conference_id",                                                null: false
-    t.string   "title",                           limit: 255,                  null: false
-    t.string   "subtitle",                        limit: 255
-    t.string   "event_type",                      limit: 255, default: "talk"
+    t.integer  "conference_id",                                      null: false
+    t.string   "title",                 limit: 255,                  null: false
+    t.string   "subtitle",              limit: 255
+    t.string   "event_type",            limit: 255, default: "talk"
     t.integer  "time_slots"
-    t.string   "state",                           limit: 255, default: "new",  null: false
-    t.string   "language",                        limit: 255
+    t.string   "state",                 limit: 255, default: "new",  null: false
+    t.string   "language",              limit: 255
     t.datetime "start_time"
     t.text     "abstract"
     t.text     "description"
-    t.boolean  "public",                                      default: true
-    t.string   "logo_file_name",                  limit: 255
-    t.string   "logo_content_type",               limit: 255
+    t.boolean  "public",                            default: true
+    t.string   "logo_file_name",        limit: 255
+    t.string   "logo_content_type",     limit: 255
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
     t.integer  "track_id"
     t.integer  "room_id"
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.float    "average_rating"
-    t.integer  "event_ratings_count",                         default: 0
+    t.integer  "event_ratings_count",               default: 0
     t.text     "note"
     t.text     "submission_note"
-    t.integer  "speaker_count",                               default: 0
-    t.integer  "event_feedbacks_count",                       default: 0
+    t.integer  "speaker_count",                     default: 0
+    t.integer  "event_feedbacks_count",             default: 0
     t.float    "average_feedback"
-    t.string   "guid",                            limit: 255
-    t.boolean  "do_not_record",                               default: false
-    t.string   "recording_license",               limit: 255
-    t.integer  "number_of_repeats",                           default: 1
-    t.text     "other_locations"
-    t.text     "methods"
-    t.text     "resources"
-    t.text     "target_audience_experience"
-    t.text     "target_audience_experience_text"
+    t.string   "guid",                  limit: 255
+    t.boolean  "do_not_record",                     default: false
+    t.string   "recording_license",     limit: 255
     t.text     "tech_rider"
   end
 
@@ -206,16 +200,15 @@ ActiveRecord::Schema.define(version: 20160221162627) do
   add_index "events", ["state"], name: "index_events_on_state"
 
   create_table "expenses", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",          limit: 255
     t.decimal  "value"
     t.boolean  "reimbursed"
     t.integer  "person_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.integer  "conference_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
-  add_index "expenses", ["conference_id"], name: "index_expenses_on_conference_id"
   add_index "expenses", ["person_id"], name: "index_expenses_on_person_id"
 
   create_table "im_accounts", force: :cascade do |t|
@@ -251,11 +244,11 @@ ActiveRecord::Schema.define(version: 20160221162627) do
 
   create_table "mail_templates", force: :cascade do |t|
     t.integer  "conference_id"
-    t.string   "name"
-    t.string   "subject"
+    t.string   "name",          limit: 255
+    t.string   "subject",       limit: 255
     t.text     "content"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
   end
 
   add_index "mail_templates", ["conference_id"], name: "index_mail_templates_on_conference_id"
@@ -308,10 +301,10 @@ ActiveRecord::Schema.define(version: 20160221162627) do
     t.integer  "conference_id",                            null: false
     t.string   "name",          limit: 255,                null: false
     t.integer  "size"
+    t.boolean  "public",                    default: true
     t.datetime "created_at",                               null: false
     t.datetime "updated_at",                               null: false
     t.integer  "rank"
-    t.boolean  "public",                    default: true
   end
 
   add_index "rooms", ["conference_id"], name: "index_rooms_on_conference_id"
@@ -354,6 +347,21 @@ ActiveRecord::Schema.define(version: 20160221162627) do
   end
 
   add_index "tracks", ["conference_id"], name: "index_tracks_on_conference_id"
+
+  create_table "transport_needs", force: :cascade do |t|
+    t.integer  "person_id"
+    t.integer  "conference_id"
+    t.datetime "at"
+    t.string   "transport_type"
+    t.integer  "seats"
+    t.boolean  "booked"
+    t.text     "note"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "transport_needs", ["conference_id"], name: "index_transport_needs_on_conference_id"
+  add_index "transport_needs", ["person_id"], name: "index_transport_needs_on_person_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                limit: 255, default: "",          null: false

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -136,6 +136,7 @@ FactoryGirl.define do
     max_timeslots 20
     feedback_enabled true
     expenses_enabled true
+    transport_needs_enabled true
     schedule_public true
     timezone 'Berlin'
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -135,6 +135,7 @@ FactoryGirl.define do
     default_timeslots 4
     max_timeslots 20
     feedback_enabled true
+    expenses_enabled true
     schedule_public true
     timezone 'Berlin'
 


### PR DESCRIPTION
People attending conferences may be in need of transportation, especially if the location is not easily reachable. Depending on how the conference is ran, the organizers might be in charge of providing such a service for their speakers, for instance. We've had such a situation earlier this year. Instead of maintaining the list of such demands externally, this patch set allows tracking such information from frab.

A TransportNeed model belongs to both a person and a conference and is just yet another data type with a `has_many` association. A new reports module is added to give organizers a comprehensive overview on future transportation needs of a conference.