### PR TITLE
Add support for Redmine tickets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jquery-ui-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 
+gem 'activeresource'
 gem 'acts_as_commentable'
 gem 'bcrypt-ruby'
 gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,10 @@ GEM
       activemodel (= 4.2.5.1)
       activesupport (= 4.2.5.1)
       arel (~> 6.0)
+    activeresource (4.0.0)
+      activemodel (~> 4.0)
+      activesupport (~> 4.0)
+      rails-observers (~> 0.1.1)
     activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -173,6 +177,8 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     railties (4.2.5.1)
       actionpack (= 4.2.5.1)
       activesupport (= 4.2.5.1)
@@ -235,6 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activeresource
   acts_as_commentable
   bcrypt-ruby
   bullet

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To start frab in the production environment run
 
 ## Ticket Server
 
-frab supports OTRS and RT ticket servers. Instead of sending
+frab supports OTRS, RT and Redmine ticket servers. Instead of sending
 event acceptance/rejection mails directly to submitters, frab adds
 a ticket to a request tracker.
 

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -16,6 +16,7 @@ class TicketsController < ApplicationController
                                               title: server.create_ticket_title(t(:your_submission, locale: @event.language), @event),
                                               requestors: server.create_ticket_requestors(@event.speakers),
                                               owner_email: current_user.email,
+                                              event_url: event_url(@event),
                                               test_only: params[:test_only])
     rescue => ex
       return redirect_to event_path(id: params[:event_id], method: :get), alert: "Failed to create ticket: #{ex.message}"

--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -1,13 +1,9 @@
 module TicketsHelper
   def get_ticket_view_url(remote_id = '0')
     return if @conference.nil?
-    if @conference.ticket_type == 'otrs'
-      if is_a_number(remote_id)
-        OtrsTickets::Helper.get_ticket_view_url(@conference, remote_id.to_i)
-      end
-    elsif @conference.ticket_type == 'rt'
-      RTTickets::Helper.get_ticket_view_url(@conference, remote_id)
-    end
+
+    ticket_module = @conference.get_ticket_module
+    ticket_module::Helper.get_ticket_view_url @conference, remote_id
   end
 
   private

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,5 +1,5 @@
 class Conference < ActiveRecord::Base
-  TICKET_TYPES = %w(otrs rt integrated)
+  TICKET_TYPES = %w(otrs rt redmine integrated)
 
   has_many :availabilities, dependent: :destroy
   has_many :conference_users, dependent: :destroy
@@ -177,10 +177,10 @@ class Conference < ActiveRecord::Base
   end
 
   def get_ticket_module
-    if self.ticket_type == 'otrs'
-      return OtrsTickets
-    else
-      return RTTickets
+    case
+      when self.ticket_type == 'otrs'    then OtrsTickets
+      when self.ticket_type == 'redmine' then RedmineTickets
+      else RTTickets
     end
   end
 

--- a/app/views/conferences/_form_ticket_server.html.haml
+++ b/app/views/conferences/_form_ticket_server.html.haml
@@ -4,7 +4,7 @@
     = ts.input :url, hint: "URL of your ticket system, for example https://localhost/otrs/"
     = ts.input :queue, hint: "Name of this events queue"
     = ts.input :user, hint: "Username used to create tickets"
-    = ts.input :password, hint: "Password used to log into ticket system"
+    = ts.input :password, hint: "Password or API access key used to log into ticket system"
 
   .actions
     = f.button :submit, class: 'primary'

--- a/lib/redmine_tickets.rb
+++ b/lib/redmine_tickets.rb
@@ -1,0 +1,88 @@
+module RedmineTickets
+  #
+  # Rails Views
+  #
+  module Helper
+    def self.get_ticket_view_url(conference, remote_id)
+      return if conference.ticket_server.nil?
+      uri = URI.parse(conference.ticket_server.url)
+      uri.path += "issues/#{remote_id}"
+      uri.to_s
+    end
+  end
+
+  #
+  # RT Server
+  #
+  class RedmineAdapter
+    require 'uri'
+    require 'active_resource'
+
+    def initialize(c, l)
+      @conference = c
+      @logger = l
+      @test_only = false
+    end
+    attr_accessor :test_only
+
+    class Issue < ActiveResource::Base
+      self.include_root_in_json = true
+
+      class << self
+        def configure(&block)
+          instance_eval &block
+        end
+
+        def key=(val)
+          self.headers['X-Redmine-API-Key'] = val
+        end
+      end
+    end
+
+    def create_issue(args)
+      ticket_server = @conference.ticket_server
+
+      Issue.configure do
+        self.site = ticket_server.url
+        self.user = ticket_server.user
+        self.key = ticket_server.password
+      end
+
+      issue = Issue.new(subject: args[:title],
+                        description: "#{args[:event_url]}\nTicket created by #{args[:owner_email]}",
+                        project_id: ticket_server.queue)
+
+      if @test_only
+        @logger.info @uri.path
+        @logger.info "content => #{args}"
+        return
+      end
+
+      issue.save
+      issue.id
+    end
+
+  end
+
+  def self.create_remote_ticket(args = {})
+    args.reverse_update(body: '', test_only: false)
+    @conference = args[:conference]
+
+    ticket_system = RedmineAdapter.new(@conference, Rails.logger)
+    ticket_system.test_only = args[:test_only]
+    ticket_system.create_issue(args)
+  end
+
+  def self.create_ticket_title(prefix, event)
+    "#{prefix} '#{event.title.truncate(30)}'"
+  end
+
+  def self.create_ticket_requestors(people)
+    people.collect { |p|
+      name = "#{p.first_name} #{p.last_name}"
+      name.delete!(',')
+      { name: name, email: p.email }
+    }
+  end
+
+end


### PR DESCRIPTION
Allow users to configure a Redmine ticket server backend.
This implementation lets `ActiveResource` handle all the json/REST magic.

The 'password' field of the configuration carries an API key instead, as
this is how their REST API works, so I tweaked the help text a bit.

From `TicketsHelper::get_ticket_view_url`, use `Conference::get_ticket_module`,
as that already does all the string-to-module dance for us.

The patch also adds an `:event_url` to the hashmap that is passed to the
`create_remote_ticket` implementations, so the modules can include a URL to
the ticket that points back to the frab event.
