### PR TITLE
event: calculate available start times in event form

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -124,6 +124,7 @@ class EventsController < ApplicationController
   def new
     authorize! :crud, Event
     @event = Event.new
+    @start_time_options = @conference.days.map { |day| [ day.to_s, day.start_times ] }
 
     respond_to do |format|
       format.html # new.html.erb
@@ -134,6 +135,8 @@ class EventsController < ApplicationController
   def edit
     @event = Event.find(params[:id])
     authorize! :update, @event
+
+    @start_time_options = @event.possible_start_times
   end
 
   # GET /events/2/edit_people
@@ -156,6 +159,7 @@ class EventsController < ApplicationController
       if @event.save
         format.html { redirect_to(@event, notice: 'Event was successfully created.') }
       else
+        @start_time_options = @conference.days.map { |day| [ day.to_s, day.start_times ] }
         format.html { render action: 'new' }
       end
     end
@@ -171,6 +175,7 @@ class EventsController < ApplicationController
         format.html { redirect_to(@event, notice: 'Event was successfully updated.') }
         format.js   { head :ok }
       else
+        @start_time_options = @event.possible_start_times
         format.html { render action: 'edit' }
         format.js { render json: @event.errors, status: :unprocessable_entity }
       end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -26,14 +26,18 @@ class Day < ActiveRecord::Base
     }
   end
 
-  def start_times
+  def start_times_map
     times = []
     time = start_date
     while time <= end_date
-      times << I18n.l(time, format: :pretty_datetime)
+      times << yield(time, I18n.l(time, format: :pretty_datetime))
       time = time.since(conference.timeslot_duration.minutes)
     end
     times
+  end
+
+  def start_times
+    start_times_map { |time, pretty| pretty }
   end
 
   def label

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -236,6 +236,49 @@ class Event < ActiveRecord::Base
     self
   end
 
+  def possible_start_times
+    possible = {}
+
+    # Retrieve a list of persons that are presenting this event,
+    # and filter out those who don't have any availabilities configured.
+
+    event_persons = self.event_people.presenter.group(:person_id, :id)
+                         .select { |ep| ep.person.availabilities.any? }
+    person_ids = event_persons.map { |ep| ep.person_id }
+
+    self.conference.days.each do |day|
+      availabilities = Availability.where(person: person_ids, day: day)
+
+      times = day.start_times_map do |time, pretty|
+        # People with no availability at all are not present in person_ids.
+        # Hence, if the number of availability records for this day is less
+        # than the number of presenters in person_ids, we know that at least
+        # one of them is not available.
+
+        if availabilities.length == person_ids.length
+          presenters_available = availabilities.map { |a| a.within_range?(time) }
+        else
+          presenters_available = [ false ]
+        end
+
+        if presenters_available.all?
+          [pretty, time.to_s]
+        elsif self.start_time == time
+          # Special case: if the event is already scheduled, offer that start time
+          # in the list as well, but add a warning, so that records are not accidentally
+          # modified through HTML forms.
+
+          [pretty + " (not all presenters available!)", time.to_s]
+        end
+      end
+
+      times.compact!
+      possible[day.to_s] = times if times.any?
+    end
+
+    possible
+  end
+
   private
 
   def generate_guid

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -18,7 +18,8 @@
     = f.input :state, collection: Event.state_machine.states.map { |st| [st.display_name, st.name.to_s] }
   %fieldset.inputs
     %legend Time and place
-    = f.input :start_time, collection: @conference.days, as: :grouped_select, group_method: :start_times, include_blank: true, selected: event_start_time
+    = f.input :start_time do
+      = f.select :start_time, grouped_options_for_select(@start_time_options, @event.start_time), { include_blank: true }
     = f.association :room, collection: @conference.rooms
   %fieldset.inputs
     %legend Detailed description

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -106,4 +106,31 @@ class EventTest < ActiveSupport::TestCase
     availability.update(start_date: conference.days.last.start_date)
     refute_empty first_event.reload.conflicts
   end
+
+  test 'possible start times for event' do
+    conference = create(:three_day_conference_with_events)
+    event = conference.events.first
+    day = conference.days.first
+
+    event_person_a = create(:event_person, event: event)
+    person_a = event_person_a.person
+    availability = create(:availability, person: person_a, conference: conference,
+                                         start_date: day.start_date,
+                                         end_date: day.start_date + 2.hours)
+
+    event_person_b = create(:event_person, event: event)
+    person_b = event_person_b.person
+    availability = create(:availability, person: person_b, conference: conference,
+                                         start_date: day.start_date + 1.hours,
+                                         end_date: day.start_date + 3.hours)
+
+    possible = event.possible_start_times
+    possible_days = possible.keys
+    assert possible_days.count == 1
+
+    possible_times = possible[possible_days.first]
+
+    # 5 possible time slots, plus 1 extra for the one the event is currently scheduled on
+    assert possible_times.count == 6
+  end
 end


### PR DESCRIPTION
In the form for events, intersect the availability for all presenting persons, and only display those as options in the `start_time` drop down menu.

In order not to break records that have a conflicting time set, the current value is special-cased and marked accordingly. This way, people can still save such an event without accidentally altering the start time.

For this to work, the SimpleForm wrapper is provided with a block, so the default Rails form helper can kick in and make use of `grouped_options_for_select()`.