### PR TITLE
Some minor report tweaks

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -100,6 +100,15 @@ class ReportsController < ApplicationController
       end
 
       @extra_fields << :expenses
+    when 'non_attending_speakers'
+      r = Person.joins(events: :conference).
+        where('conferences.id': @conference.id).
+        where('event_people.event_role': 'speaker').
+        where("event_people.role_state != 'attending'").
+        where('events.public': true).
+        where('events.start_time > ?', Time.now).
+        where('events.start_time < ?', Time.now.since(2.hours)).
+        where('events.state': ['unconfirmed', 'confirmed']).order('events.start_time ASC').group(:'people.id')
     end
 
     unless r.nil? or r.empty?

--- a/app/views/reports/_events_table.html.haml
+++ b/app/views/reports/_events_table.html.haml
@@ -7,7 +7,7 @@
         %th= sort_link @search, :track_name, "Track", term: params[:term]
         %th= sort_link @search, :event_type, term: params[:term]
         %th= sort_link @search, :state, "State", term: params[:term]
-        %th= sort_link @search, :created_at, term: params[:term]
+        %th= sort_link @search, :start_time, term: params[:term]
         - if @extra_fields.include?(:tech_rider)
           %th Tech rider
       - else
@@ -15,7 +15,7 @@
         %th Track
         %th Event type
         %th State
-        %th Created at
+        %th Start time
         - if @extra_fields.include?(:tech_rider)
           %th Tech rider
       %th
@@ -30,7 +30,7 @@
         %td= event.track.try(:name)
         %td= event.event_type
         %td= event.state
-        %td= l(event.created_at.to_date)
+        %td= event.start_time ? l(event.start_time) : ""
         - if @extra_fields.include?(:tech_rider)
           %td= event.tech_rider
         %td.buttons

--- a/app/views/reports/_report_menu.html.haml
+++ b/app/views/reports/_report_menu.html.haml
@@ -22,6 +22,7 @@
   %li= link_to "people with more than one submission", report_on_people_path("people_with_more_than_one")
   - if @conference.expenses_enabled?
     %li= link_to "people with non-reimbursed expenses", report_on_people_path("people_with_non_reimbursed_expenses")
+  %li= link_to "non-attending speakers for the next 2 hours", report_on_people_path("non_attending_speakers")
 %p Statistics
 %ul
   %li= link_to "used timeslots (hours)", report_on_statistics_path("event_timeslot_sum")


### PR DESCRIPTION
In reports, users are very likely more interested in when an event is about
to take place, rather than when it was created.

Also add another report that shows non-attending speakers that have a talk scheduled within the next two hours.