### PR TITLE
config/initializers: pass SMTP_AUTHENTICATION

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -3,7 +3,7 @@ ActionMailer::Base.default_url_options = {
   protocol: ENV.fetch('FRAB_PROTOCOL')
 }
 if ENV['SMTP_ADDRESS']
-  %w(ADDRESS PORT DOMAIN USER_NAME PASSWORD).each do |setting|
+  %w(ADDRESS PORT DOMAIN USER_NAME PASSWORD AUTHENTICATION).each do |setting|
     next unless ENV["SMTP_#{setting}"].present?
     ActionMailer::Base.smtp_settings[setting.downcase.to_sym] = ENV["SMTP_#{setting}"]
   end


### PR DESCRIPTION
This is needed in order to configure SMTP authentication types
explicitly.