### PR TITLE
production env: hook up exception_notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem 'sucker_punch'
 gem 'transitions', require: ['transitions', 'active_record/transitions']
 gem 'will_paginate'
 
+group :production do
+  gem 'exception_notification'
+end
+
 group :development, :test do
   gem 'bullet'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
       dotenv (= 2.1.0)
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
+    exception_notification (4.1.4)
+      actionmailer (~> 4.0)
+      activesupport (~> 4.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -243,6 +246,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   database_cleaner
   dotenv-rails
+  exception_notification
   factory_girl_rails (~> 4.0)
   github-markdown
   haml

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,14 @@ Frab::Application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  if ENV['EXCEPTION_EMAIL'].present? and ENV['FROM_EMAIL'].present?
+    Rails.application.config.middleware.use ExceptionNotification::Rack,
+      email: {
+        email_prefix: "frab on #{ENV['FRAB_HOST']}: ",
+        sender_address: "frab <#{ENV['FROM_EMAIL']}>",
+        exception_recipients: ENV['EXCEPTION_EMAIL']
+      }
+  end
+
 end


### PR DESCRIPTION
Hook up this very handy tool for notifing admins about exceptions
in production systems. This is off by default and needs to be enabled
via ENV['EXCEPTION_EMAIL'].