### PR TITLE
add basic capistrano config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ specifications/
 .vagrant
 doc/
 tags
+config/deploy/production.rb

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+.env
 .env.local
 .env.production
 .ruby-version

--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,27 @@
+# Load DSL and set up stages
+require 'capistrano/setup'
+
+# Include default deployment tasks
+require 'capistrano/deploy'
+
+# Include tasks from other gems included in your Gemfile
+#
+# For documentation on these, see for example:
+#
+#   https://github.com/capistrano/rvm
+#   https://github.com/capistrano/rbenv
+#   https://github.com/capistrano/chruby
+#   https://github.com/capistrano/bundler
+#   https://github.com/capistrano/rails
+#   https://github.com/capistrano/passenger
+#
+#require 'capistrano/rvm'
+require 'capistrano/bundler'
+require 'capistrano/rails/assets'
+require 'capistrano/rails/migrations'
+#require 'capistrano/puma'
+#require 'capistrano/passenger'
+require "airbrussh/capistrano"
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Capfile
+++ b/Capfile
@@ -23,5 +23,8 @@ require 'capistrano/rails/migrations'
 #require 'capistrano/passenger'
 require "airbrussh/capistrano"
 
+require 'dotenv'
+Dotenv.load
+
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,16 @@ gem 'sqlite3', group: :sqlite3
 # Use Puma as the app server
 gem 'puma'
 
+# Capistrano for deployment
+group :capistrano do
+  gem 'airbrussh'
+  gem 'capistrano', '~> 3.4.0', require: false
+  gem 'capistrano-rails',   require: false
+  gem 'capistrano-bundler', require: false
+  gem 'capistrano-rvm',     require: false
+  gem 'capistrano3-puma',   require: false
+end
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 gem 'jquery-migrate-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       tzinfo (~> 1.1)
     acts_as_commentable (4.0.2)
     addressable (2.4.0)
+    airbrussh (0.7.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (6.0.3)
     bcrypt (3.1.10)
     bcrypt-ruby (3.1.5)
@@ -60,6 +62,22 @@ GEM
       uniform_notifier (~> 1.9.0)
     byebug (8.2.2)
     cancancan (1.13.1)
+    capistrano (3.4.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (~> 1.3)
+    capistrano-bundler (1.1.4)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-rails (1.1.6)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
+    capistrano3-puma (1.2.1)
+      capistrano (~> 3.0)
+      puma (>= 2.6)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -121,6 +139,9 @@ GEM
     minitest (5.8.4)
     multi_json (1.11.2)
     mysql2 (0.4.3)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     paper_trail (4.1.0)
@@ -217,6 +238,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    sshkit (1.9.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     sucker_punch (2.0.1)
       concurrent-ruby (~> 1.0.0)
     thor (0.19.1)
@@ -239,9 +263,15 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   acts_as_commentable
+  airbrussh
   bcrypt-ruby
   bullet
   cancancan
+  capistrano (~> 3.4.0)
+  capistrano-bundler
+  capistrano-rails
+  capistrano-rvm
+  capistrano3-puma
   cocoon
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,16 @@
+# config valid only for current version of Capistrano
+lock '3.4.0'
+
+set :application, 'frab'
+set :repo_url, 'https://github.com/frab/frab.git'
+
+# Default branch is :master
+set :branch, 'master'
+
+set :use_sudo,        false
+set :stage,           :production
+set :deploy_via,      :remote_cache
+set :ssh_options,     forward_agent: true, user: fetch(:user), keys: %w(~/.ssh/id_rsa.pub)
+set :bundle_without, %w(capistrano development test postgresql sqlite3).join(' ')
+set :linked_files, %w(config/database.yml .env.production .ruby-version)
+set :linked_dirs,  %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,6 +6,7 @@ set :repo_url, 'https://github.com/frab/frab.git'
 
 # Default branch is :master
 set :branch, 'master'
+set :user, ENV['CAP_USER']
 
 set :use_sudo,        false
 set :stage,           :production

--- a/config/deploy/production.rb.example
+++ b/config/deploy/production.rb.example
@@ -1,0 +1,4 @@
+server '127.0.0.1', roles: %w{app db web}, primary: true, port: '22'
+set :deploy_to, '/srv/frab/apps'
+set :tmp_dir, '/srv/frab/tmp'
+set :user, 'frab'

--- a/env.example
+++ b/env.example
@@ -9,3 +9,5 @@ SMTP_USER_NAME=
 SMTP_PASSWORD=
 FRAB_CURRENCY_UNIT="€"
 FRAB_CURRENCY_FORMAT="%n%u"
+# only works in .env
+CAP_USER=frab


### PR DESCRIPTION
Removed all host specific parts from my capistrano config. Should be possible to configure this for specific deployments by copying `production.rb.example` to `production.rb` and fill in / override the values as needed.
RVM and puma/passenger gems are not included however, maybe they should all be there by default?