### PR TITLE
password_controller: set user.confirmed_at when password was changed

### DIFF
--- a/app/controllers/cfp/passwords_controller.rb
+++ b/app/controllers/cfp/passwords_controller.rb
@@ -33,6 +33,8 @@ class Cfp::PasswordsController < ApplicationController
 
     if @user.reset_password(params[:user])
       login_as @user
+      @user.skip_confirmation!
+      @user.save
       redirect_to cfp_person_path, notice: t(:"cfp.password_updated")
     else
       @user.reset_password_token = params[:user][:reset_password_token]


### PR DESCRIPTION
When the password was changed successfully, the user must have had access to
a mail sent to his mailbox, which is, technically, nothing less than a
confirmation. Hence, set the confirmed_at field in this case.

The problem here is that people who can't log in desperately tried to reset
their password, and even succeeded in that, but were then refused to login
on the next attempt.