### PR TITLE
Reveal person's availabilities and export event's language 

### DIFF
--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -17,6 +17,15 @@ class AvailabilitiesController < ApplicationController
     redirect_to(person_url(@person), notice: 'Availibility was successfully updated.')
   end
 
+  def show
+    @availabilities = @person.availabilities_in(@conference)
+    respond_to do |format|
+    format.html { render :_form }
+    format.json { render json: @availabilities.to_json }
+    format.xml  { render xml: @availabilities.to_xml }
+    end
+  end
+
   private
 
   def find_person

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -33,7 +33,9 @@ class EventsController < ApplicationController
         duration: (e.time_slots * e.conference.timeslot_duration).minutes,
         title: e.title,
         abstract: e.abstract,
-        speakers: e.speakers.map(&:public_name).join(', ')
+        language: e.language,
+        speakers: e.speakers.map(&:public_name).join(', '),
+        speaker_ids: e.speakers.map(&:id)
       }
     }
 


### PR DESCRIPTION
The halfnarp tool has gained a planning interface called fullnarp which graphically marks conflicts in speaker avaliabilites and imbalanced event language at a given time slot.

To properly work, it needs language and all speaker's availabilites. Language can be exported directly. To map availabilities, we first need to get people ids to later xref with list of availabilities. Later we scrape all person's availabilities.