### PR TITLE
Never paginate for MIME types with no concept of paging

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -9,11 +9,10 @@ class ConferencesController < ApplicationController
   # GET /conferences
   def index
     result = search params
-    @conferences = result.paginate page: page_param
 
     respond_to do |format|
-      format.html
-      format.json { render json: @conferences }
+      format.html { @conferences = result.paginate page: page_param }
+      format.json { render json: result }
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,10 +10,10 @@ class EventsController < ApplicationController
 
     @events = search @conference.events.includes(:track), params
 
+    clean_events_attributes
     respond_to do |format|
       format.html {
         @events = @events.paginate page: page_param
-        clean_events_attributes
       }
       format.xml  { render xml: @events }
       format.json { render json: @events }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,12 +8,13 @@ class EventsController < ApplicationController
   def index
     authorize! :read, Event
 
-    result = search @conference.events.includes(:track), params
-    @events = result.paginate page: page_param
+    @events = search @conference.events.includes(:track), params
 
-    clean_events_attributes
     respond_to do |format|
-      format.html # index.html.erb
+      format.html {
+        @events = @events.paginate page: page_param
+        clean_events_attributes
+      }
       format.xml  { render xml: @events }
       format.json { render json: @events }
     end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,7 +10,7 @@ class PeopleController < ApplicationController
     @people = search Person.involved_in(@conference), params
 
     respond_to do |format|
-      format.html { @people = result.paginate page: page_param }
+      format.html { @people = @people.paginate page: page_param }
       format.xml  { render xml: @people }
       format.json { render json: @people }
     end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,11 +7,10 @@ class PeopleController < ApplicationController
   # GET /people.xml
   def index
     authorize! :administrate, Person
-    result = search Person.involved_in(@conference), params
-    @people = result.paginate page: page_param
+    @people = search Person.involved_in(@conference), params
 
     respond_to do |format|
-      format.html
+      format.html { @people = result.paginate page: page_param }
       format.xml  { render xml: @people }
       format.json { render json: @people }
     end
@@ -19,7 +18,6 @@ class PeopleController < ApplicationController
 
   def speakers
     authorize! :administrate, Person
-    @people = Person.speaking_at(@conference).accessible_by(current_ability)
 
     respond_to do |format|
       format.html do
@@ -27,6 +25,7 @@ class PeopleController < ApplicationController
         @people = result.paginate page: page_param
       end
       format.text do
+        @people = Person.speaking_at(@conference).accessible_by(current_ability)
         render text: @people.map(&:email).join("\n")
       end
     end

--- a/app/controllers/recent_changes_controller.rb
+++ b/app/controllers/recent_changes_controller.rb
@@ -12,7 +12,7 @@ class RecentChangesController < ApplicationController
     respond_to do |format|
       format.html
       format.xml { render xml: @all_versions }
-      format.json { render json: @versions.to_json }
+      format.json { render json: @all_versions.to_json }
     end
   end
 


### PR DESCRIPTION
Currently exporting to JSON or XML will paginate leaving the requestor no way or even a path to ask for more.

Solution: Do not paginate for anything than html.