### PR TITLE
GROUP BY without an aggregate function makes no sense

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,13 +38,13 @@ class Person < ActiveRecord::Base
   # validates_inclusion_of :gender, in: GENDERS, allow_nil: true
 
   scope :involved_in, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id)
   }
   scope :speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed)).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed))
   }
   scope :publicly_speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed)).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed))
   }
   scope :confirmed, ->(conference) {
     joins(events: :conference).where("conferences.id": conference.id).where("events.state": 'confirmed')


### PR DESCRIPTION
This fixes the problem in my example conference where of the two people in the only event only one the first would show up in every list that uses the involved_in function, most notably people_controller.rb.

The resulting query was

SELECT DISTINCT "people".* FROM "people" INNER JOIN "event_people" ON "event_people"."person_id" = "people"."id" INNER JOIN "events" ON "events"."id" = "event_people"."event_id" INNER JOIN "conferences" ON "conferences"."id" = "events"."conference_id" WHERE "conferences"."id" = 1 GROUP BY "people.id" LIMIT 100 OFFSET 0

and yielded an incorrect result (on the sqlite3 I found myself with after following the guide from README).

Without the GROUP BY the statement yields the correct rows from people, with the DISTINCT statement ensuring what I only can guess was meant to be done with the GROUP BY.