### PR TITLE
Replace group by with uniq

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -42,7 +42,7 @@ class Conference < ActiveRecord::Base
   scope :has_submission, ->(person) {
     joins(events: [{ event_people: :person }])
       .where(EventPerson.arel_table[:event_role].in(%w(speaker moderator)))
-      .where(Person.arel_table[:id].eq(person.id)).group(:"conferences.id")
+      .where(Person.arel_table[:id].eq(person.id)).uniq
   }
 
   scope :creation_order, -> { order('conferences.created_at DESC') }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,13 +38,13 @@ class Person < ActiveRecord::Base
   # validates_inclusion_of :gender, in: GENDERS, allow_nil: true
 
   scope :involved_in, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id).uniq
   }
   scope :speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed)).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed)).uniq
   }
   scope :publicly_speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed)).group(:"people.id")
+    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed)).uniq
   }
   scope :confirmed, ->(conference) {
     joins(events: :conference).where("conferences.id": conference.id).where("events.state": 'confirmed')

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -189,6 +189,10 @@ FactoryGirl.define do
     person
     event
     event_role 'speaker'
+
+    factory :confirmed_event_person do
+      role_state 'confirmed'
+    end
   end
 
   factory :event_rating do

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -38,4 +38,23 @@ class ConferenceTest < ActiveSupport::TestCase
     assert_equal 3, conference.days.size
     assert_equal Date.today.since(3.days).since(10.hours), conference.days.last.start_date
   end
+
+  test '#has_submission' do
+    conference = create(:three_day_conference_with_events)
+    event = conference.events.first
+    person = create(:person)
+    create(:confirmed_event_person, event: event, person: person)
+    assert Conference.has_submission(person)
+
+    conference = create(:three_day_conference_with_events)
+    event = conference.events.first
+    create(:confirmed_event_person, event: event, person: person)
+    create(:confirmed_event_person, event: event)
+    assert_equal 2, Conference.has_submission(person).count
+
+    conference = create(:three_day_conference_with_events)
+    event = conference.events.first
+    create(:event_person, event: event, person: person, event_role: 'coordinator')
+    assert_equal 2, Conference.has_submission(person).count
+  end
 end

--- a/test/models/event_person_test.rb
+++ b/test/models/event_person_test.rb
@@ -38,7 +38,26 @@ class EventPersonTest < ActiveSupport::TestCase
     person2 = FactoryGirl.create(:person)
     event_person1 = FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
     event_person2 = FactoryGirl.create(:event_person, event: event, person: person2, event_role: 'speaker', role_state: 'confirmed')
-    assert Person.speaking_at(conference).count == 2
+    persons = Person.involved_in(conference)
+    assert_equal 2, persons.count
+    assert_includes persons, person1
+
+    FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'coordinator', role_state: 'confirmed')
+    assert_equal 2, Person.involved_in(conference).count
+
+    event2 = FactoryGirl.create(:event, conference: conference, state: 'confirmed')
+    FactoryGirl.create(:event_person, event: event2, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    assert_equal 2, Person.involved_in(conference).count
   end
 
+  test 'check speaking_at returns conferences speakers' do
+    conference = FactoryGirl.create(:three_day_conference_with_events)
+    event = conference.events.first
+    person1 = FactoryGirl.create(:person)
+    FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
+    assert_equal 1, Person.speaking_at(conference).count
+    person2 = FactoryGirl.create(:person)
+    FactoryGirl.create(:event_person, event: event, person: person2, event_role: 'coordinator', role_state: 'confirmed')
+    assert_equal 1, Person.speaking_at(conference).count
+  end
 end

--- a/test/models/event_person_test.rb
+++ b/test/models/event_person_test.rb
@@ -30,4 +30,15 @@ class EventPersonTest < ActiveSupport::TestCase
     assert !event_person.available_between?(today.to_time.change(hour: 0), today.to_time.change(hour: 11))
     assert !event_person.available_between?(today.to_time.change(hour: 13), today.to_time.change(hour: 24))
   end
+
+  test 'check involved_in returns correct number of people' do
+    conference = FactoryGirl.create(:three_day_conference)
+    event = FactoryGirl.create(:event, conference: conference, state: 'confirmed')
+    person1 = FactoryGirl.create(:person)
+    person2 = FactoryGirl.create(:person)
+    event_person1 = FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
+    event_person2 = FactoryGirl.create(:event_person, event: event, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    assert Person.speaking_at(conference).count == 2
+  end
+
 end


### PR DESCRIPTION
In response to #227, I'm pretty confident uniq is required to avoid duplicates due to the join statements. Tests confirm that. I'm not 100% confident changing this doesn't break functionality which depended on the GROUP BY, which returns an hash instead of an array, but we should fix the bug first.