### PR TITLE
Factory girl include cleanup

### DIFF
--- a/test/controllers/call_for_participations_controller_test.rb
+++ b/test/controllers/call_for_participations_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CallForParticipationsControllerTest < ActionController::TestCase
   setup do
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
     login_as(:admin)
   end
@@ -25,7 +25,7 @@ class CallForParticipationsControllerTest < ActionController::TestCase
   end
 
   test 'should create cfp' do
-    new_conference = FactoryGirl.create(:conference)
+    new_conference = create(:conference)
     params = {
       call_for_participation: call_for_participation_params,
       conference_acronym: new_conference.acronym

--- a/test/controllers/cfp/availabilities_controller_test.rb
+++ b/test/controllers/cfp/availabilities_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Cfp::AvailabilitiesControllerTest < ActionController::TestCase
   setup do
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
     login_as(:submitter)
   end

--- a/test/controllers/cfp/confirmations_controller_test.rb
+++ b/test/controllers/cfp/confirmations_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Cfp::ConfirmationsControllerTest < ActionController::TestCase
   setup do
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
   end
 
@@ -12,7 +12,7 @@ class Cfp::ConfirmationsControllerTest < ActionController::TestCase
   end
 
   test 'resends confirmation instructions' do
-    user = FactoryGirl.create(:user, confirmed_at: nil)
+    user = create(:user, confirmed_at: nil)
     assert_difference 'ActionMailer::Base.deliveries.size' do
       post :create, conference_acronym: @conference.acronym, user: { email: user.email }
     end
@@ -20,7 +20,7 @@ class Cfp::ConfirmationsControllerTest < ActionController::TestCase
   end
 
   test 'performs confirmation' do
-    user = FactoryGirl.create(:user, confirmed_at: nil)
+    user = create(:user, confirmed_at: nil)
     get :show, conference_acronym: @conference.acronym, confirmation_token: user.confirmation_token
     assert_response :redirect
     assert_not_nil assigns(:current_user)

--- a/test/controllers/cfp/events_controller_test.rb
+++ b/test/controllers/cfp/events_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Cfp::EventsControllerTest < ActionController::TestCase
   setup do
-    @event = FactoryGirl.create(:event)
+    @event = create(:event)
     @conference = @event.conference
     @user = login_as(:submitter)
   end
@@ -24,13 +24,13 @@ class Cfp::EventsControllerTest < ActionController::TestCase
   end
 
   test 'should get edit' do
-    FactoryGirl.create(:event_person, event: @event, person: @user.person)
+    create(:event_person, event: @event, person: @user.person)
     get :edit, id: @event.to_param, conference_acronym: @conference.acronym
     assert_response :success
   end
 
   test 'should update event' do
-    FactoryGirl.create(:event_person, event: @event, person: @user.person)
+    create(:event_person, event: @event, person: @user.person)
     put :update, id: @event.to_param, event: event_params, conference_acronym: @conference.acronym
     assert_response :redirect
   end
@@ -38,7 +38,7 @@ class Cfp::EventsControllerTest < ActionController::TestCase
   test 'should confirm event and login user' do
     session[:user_id] = nil
     @event.update_attributes(state: 'unconfirmed')
-    event_person = FactoryGirl.create(:event_person, event: @event, person: @user.person)
+    event_person = create(:event_person, event: @event, person: @user.person)
     event_person.generate_token!
     get :confirm, conference_acronym: @conference.acronym, id: @event.id, token: event_person.confirmation_token
     assert_response :redirect
@@ -50,8 +50,8 @@ class Cfp::EventsControllerTest < ActionController::TestCase
   test 'should confirm event without user' do
     session[:user_id] = nil
     @event.update_attributes(state: 'unconfirmed')
-    person = FactoryGirl.create(:person)
-    event_person = FactoryGirl.create(:event_person, event: @event, person: person)
+    person = create(:person)
+    event_person = create(:event_person, event: @event, person: person)
     event_person.generate_token!
     get :confirm, conference_acronym: @conference.acronym, id: @event.id, token: event_person.confirmation_token
     assert_response :success

--- a/test/controllers/cfp/passwords_controller_test.rb
+++ b/test/controllers/cfp/passwords_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Cfp::PasswordsControllerTest < ActionController::TestCase
   setup do
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
   end
 
@@ -12,7 +12,7 @@ class Cfp::PasswordsControllerTest < ActionController::TestCase
   end
 
   test 'sends password reset instructions' do
-    user = FactoryGirl.create(:user)
+    user = create(:user)
     assert_difference 'ActionMailer::Base.deliveries.size' do
       post :create, conference_acronym: @conference.acronym, user: { email: user.email }
     end
@@ -22,14 +22,14 @@ class Cfp::PasswordsControllerTest < ActionController::TestCase
   end
 
   test 'displays password reset form' do
-    user = FactoryGirl.create(:user)
+    user = create(:user)
     user.send_password_reset_instructions(@call_for_participation.conference)
     get :edit, conference_acronym: @conference.acronym, reset_password_token: user.reset_password_token
     assert_response :success
   end
 
   test 'allows setting a new password' do
-    user = FactoryGirl.create(:user)
+    user = create(:user)
     user.send_password_reset_instructions(@call_for_participation.conference)
     before_digest = user.password_digest
     put :update, conference_acronym: @conference.acronym, user: { reset_password_token: user.reset_password_token, password: '123frab', password_confirmation: '123frab' }

--- a/test/controllers/cfp/people_controller_test.rb
+++ b/test/controllers/cfp/people_controller_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class Cfp::PeopleControllerTest < ActionController::TestCase
   setup do
-    @cfp_person = FactoryGirl.create(:person)
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @cfp_person = create(:person)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
     login_as(:submitter)
   end
@@ -19,7 +19,7 @@ class Cfp::PeopleControllerTest < ActionController::TestCase
 
   test 'should create cfp_person' do
     # can't have two persons on one user, so delete the one from login_as
-    user = FactoryGirl.create(
+    user = create(
       :user,
       role: 'submitter'
     )

--- a/test/controllers/cfp/sessions_controller_test.rb
+++ b/test/controllers/cfp/sessions_controller_test.rb
@@ -2,16 +2,16 @@ require 'test_helper'
 
 class Cfp::SessionsControllerTest < ActionController::TestCase
   setup do
-    @first_conference = FactoryGirl.create(:conference)
-    FactoryGirl.create(:call_for_participation, conference: @first_conference)
+    @first_conference = create(:conference)
+    create(:call_for_participation, conference: @first_conference)
 
-    @conference = FactoryGirl.create(:conference)
-    @call_for_participation = FactoryGirl.create(:call_for_participation, conference: @conference)
+    @conference = create(:conference)
+    @call_for_participation = create(:call_for_participation, conference: @conference)
 
-    @last_conference = FactoryGirl.create(:conference)
-    FactoryGirl.create(:call_for_participation, conference: @last_conference)
+    @last_conference = create(:conference)
+    create(:call_for_participation, conference: @last_conference)
 
-    @submitter = FactoryGirl.create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'submitter')
+    @submitter = create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'submitter')
   end
 
   test 'submitter can login' do

--- a/test/controllers/cfp/users_controller_test.rb
+++ b/test/controllers/cfp/users_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Cfp::UsersControllerTest < ActionController::TestCase
   setup do
-    @call_for_participation = FactoryGirl.create(:call_for_participation)
+    @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
   end
 

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 class ConferencesControllerTest < ActionController::TestCase
   setup do
-    FactoryGirl.create(:conference)
-    FactoryGirl.create(:conference)
-    @conference = FactoryGirl.create(:conference)
+    create(:conference)
+    create(:conference)
+    @conference = create(:conference)
     login_as(:admin)
   end
 
@@ -24,7 +24,7 @@ class ConferencesControllerTest < ActionController::TestCase
 
   test 'should create conference' do
     assert_difference('Conference.count') do
-      post :create, conference: FactoryGirl.attributes_for(:conference)
+      post :create, conference: attributes_for(:conference)
     end
   end
 
@@ -46,14 +46,14 @@ class ConferencesControllerTest < ActionController::TestCase
 
   test 'should add conference_day' do
     assert_difference('Day.count') do
-      @conference.days << FactoryGirl.create(:day)
+      @conference.days << create(:day)
       put :update, conference: conference_params, conference_acronym: @conference.acronym
     end
   end
 
   test 'should create conference with feedback disabled' do
     assert_difference('Conference.count') do
-      post :create, conference: FactoryGirl.attributes_for(:conference, feedback_enabled: false)
+      post :create, conference: attributes_for(:conference, feedback_enabled: false)
     end
   end
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class EventsControllerTest < ActionController::TestCase
   setup do
-    @event = FactoryGirl.create(:event)
+    @event = create(:event)
     @conference = @event.conference
     login_as(:admin)
   end
@@ -55,19 +55,19 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test 'should get cards pdf' do
-    conference = FactoryGirl.create :three_day_conference_with_events
+    conference = create :three_day_conference_with_events
     get :cards, conference_acronym: conference.acronym, format: 'pdf'
     assert_response :success
   end
 
   test 'should get accepted cards pdf' do
-    conference = FactoryGirl.create :three_day_conference_with_events
+    conference = create :three_day_conference_with_events
     get :cards, accepted: true, conference_acronym: conference.acronym, format: 'pdf'
     assert_response :success
   end
 
   test 'should get export accepted' do
-    conference = FactoryGirl.create :three_day_conference_with_events
+    conference = create :three_day_conference_with_events
     get :export_accepted, conference_acronym: conference.acronym, format: :json
     assert_response :success
     assert_includes response.body, '[{"event_id":'

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class PeopleControllerTest < ActionController::TestCase
   setup do
-    @person = FactoryGirl.create(:person)
-    @conference = FactoryGirl.create(:conference)
+    @person = create(:person)
+    @conference = create(:conference)
     login_as(:admin)
   end
 

--- a/test/controllers/public/feedback_controller_test.rb
+++ b/test/controllers/public/feedback_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Public::FeedbackControllerTest < ActionController::TestCase
   setup do
-    @event = FactoryGirl.create(:event)
+    @event = create(:event)
     @conference = @event.conference
   end
 

--- a/test/controllers/public/schedule_controller_test.rb
+++ b/test/controllers/public/schedule_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Public::ScheduleControllerTest < ActionController::TestCase
   setup do
-    @conference = FactoryGirl.create(:three_day_conference_with_events)
+    @conference = create(:three_day_conference_with_events)
   end
 
   test 'displays schedule main page' do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class SessionsControllerTest < ActionController::TestCase
   setup do
-    @first_conference = FactoryGirl.create(:conference)
-    @conference = FactoryGirl.create(:conference)
-    @last_conference = FactoryGirl.create(:conference)
-    @orga = FactoryGirl.create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'orga')
-    @submitter = FactoryGirl.create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'submitter')
+    @first_conference = create(:conference)
+    @conference = create(:conference)
+    @last_conference = create(:conference)
+    @orga = create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'orga')
+    @submitter = create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'submitter')
   end
 
   test 'admin user can login' do
@@ -33,7 +33,7 @@ class SessionsControllerTest < ActionController::TestCase
   end
 
   test 'unconfirmed user cannot login' do
-    user = FactoryGirl.create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'orga')
+    user = create(:user, password: 'frab123', password_confirmation: 'frab123', role: 'orga')
     user.confirmed_at = nil
     user.save!
     post :create, conference_acronym: @conference.acronym, user: user_param(user)

--- a/test/controllers/tickets_controller_otrs_test.rb
+++ b/test/controllers/tickets_controller_otrs_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class TicketsControllerTest < ActionController::TestCase
   setup do
-    @event = FactoryGirl.create(:event)
+    @event = create(:event)
     @conference = @event.conference
-    @person = FactoryGirl.create(:person)
-    FactoryGirl.create(:event_person, event: @event, person: @person,
+    @person = create(:person)
+    create(:event_person, event: @event, person: @person,
                                       event_role: 'submitter')
-    FactoryGirl.create(:event_person, event: @event, person: @person,
+    create(:event_person, event: @event, person: @person,
                                       event_role: 'speaker')
 
     @conference.ticket_type = 'otrs'

--- a/test/controllers/tickets_controller_rt_test.rb
+++ b/test/controllers/tickets_controller_rt_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class TicketsControllerTest < ActionController::TestCase
   setup do
-    @event = FactoryGirl.create(:event)
+    @event = create(:event)
     @conference = @event.conference
-    @person = FactoryGirl.create(:person)
-    FactoryGirl.create(:event_person, event: @event, person: @person,
+    @person = create(:person)
+    create(:event_person, event: @event, person: @person,
                                       event_role: 'submitter')
-    FactoryGirl.create(:event_person, event: @event, person: @person,
+    create(:event_person, event: @event, person: @person,
                                       event_role: 'speaker')
 
     @url = 'https://localhost/RT/'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,14 +2,14 @@ require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase
   setup do
-    @conference = FactoryGirl.create(:conference)
-    @person = FactoryGirl.create(:person)
-    @user = FactoryGirl.create(:user, person: FactoryGirl.create(:person))
+    @conference = create(:conference)
+    @person = create(:person)
+    @user = create(:user, person: create(:person))
     login_as(:admin)
   end
 
   def user_params(user_type = :user)
-    user_params = FactoryGirl.attributes_for(user_type).merge(password: 'frab123', password_confirmation: 'frab123')
+    user_params = attributes_for(user_type).merge(password: 'frab123', password_confirmation: 'frab123')
     user_params.delete(:confirmed_at)
     user_params.delete(:sign_in_count)
     user_params
@@ -55,10 +55,10 @@ class UsersControllerTest < ActionController::TestCase
   end
 
   test 'should add conference user to existing crew user' do
-    @user = FactoryGirl.create(:crew_user, person: FactoryGirl.create(:person))
+    @user = create(:crew_user, person: create(:person))
     user_attributes = { id: @user.id }
     user_attributes['conference_users_attributes'] = {
-      '0' => FactoryGirl.attributes_for(:conference_user, role: 'reviewer', conference_id: @conference.id)
+      '0' => attributes_for(:conference_user, role: 'reviewer', conference_id: @conference.id)
     }
     assert_difference('ConferenceUser.count') do
       put :update,

--- a/test/integration/set_event_public_test.rb
+++ b/test/integration/set_event_public_test.rb
@@ -4,7 +4,7 @@ class SetEventPublicTest < ActionDispatch::IntegrationTest
   setup do
     @conference = create :three_day_conference
     @event = create :event, conference: @conference
-    @conference_user = FactoryGirl.create :conference_orga, conference: @conference
+    @conference_user = create :conference_orga, conference: @conference
     sign_in(@conference_user.user)
   end
 

--- a/test/models/abilities_test.rb
+++ b/test/models/abilities_test.rb
@@ -3,32 +3,32 @@ require 'test_helper'
 class AbilitiesTest < ActiveSupport::TestCase
   setup do
     # Event
-    @event = FactoryGirl.create :event
+    @event = create :event
 
     # Conference
     @conference = @event.conference
 
     # CallForParticipation
-    @cfp = FactoryGirl.create :call_for_participation, conference: @conference
+    @cfp = create :call_for_participation, conference: @conference
 
     # Person
-    @person = FactoryGirl.create :person
+    @person = create :person
 
     # EventRating
-    @rating = FactoryGirl.create :event_rating, event: @event, rating: 4.0
+    @rating = create :event_rating, event: @event, rating: 4.0
 
     # User
-    @other_user = FactoryGirl.create :user
+    @other_user = create :user
 
-    @orga_user = FactoryGirl.create(:conference_orga, conference: @conference).user
-    @coordinator_user = FactoryGirl.create(:conference_coordinator, conference: @conference).user
-    @reviewer_user = FactoryGirl.create(:conference_reviewer, conference: @conference).user
+    @orga_user = create(:conference_orga, conference: @conference).user
+    @coordinator_user = create(:conference_coordinator, conference: @conference).user
+    @reviewer_user = create(:conference_reviewer, conference: @conference).user
 
-    @submitter_user = FactoryGirl.create :user
-    @conference_event = FactoryGirl.create :event, conference: @conference
-    FactoryGirl.create :event_person, person: @submitter_user.person, event: @conference_event
+    @submitter_user = create :user
+    @conference_event = create :event, conference: @conference
+    create :event_person, person: @submitter_user.person, event: @conference_event
 
-    @guest_user = FactoryGirl.create :user
+    @guest_user = create :user
     @guest_user.role = nil
   end
 
@@ -152,7 +152,7 @@ class AbilitiesTest < ActiveSupport::TestCase
   end
 
   test 'reviewer can read all event ratings, but only manage self' do
-    my_rating = FactoryGirl.create :event_rating, person: @reviewer_user.person
+    my_rating = create :event_rating, person: @reviewer_user.person
     ability = Ability.new @reviewer_user, @conference
     assert ability.can? :create, my_rating
     assert ability.can? :crud, my_rating
@@ -217,7 +217,7 @@ class AbilitiesTest < ActiveSupport::TestCase
   end
 
   test 'submitter has no access to event ratings' do
-    my_rating = FactoryGirl.create :event_rating, person: @submitter_user.person
+    my_rating = create :event_rating, person: @submitter_user.person
     ability = Ability.new @submitter_user, @conference
     assert ability.cannot? :read, my_rating
     assert ability.cannot? :manage, my_rating
@@ -280,7 +280,7 @@ class AbilitiesTest < ActiveSupport::TestCase
   end
 
   test 'guest has no access to event ratings' do
-    my_rating = FactoryGirl.create :event_rating, person: @guest_user.person
+    my_rating = create :event_rating, person: @guest_user.person
     ability = Ability.new @guest_user, @conference
     assert ability.cannot? :read, my_rating
     assert ability.cannot? :manage, my_rating

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class AvailabilityTest < ActiveSupport::TestCase
   setup do
-    @conference = FactoryGirl.create(:three_day_conference)
+    @conference = create(:three_day_conference)
   end
 
   test 'build_for creates availabilites for each conference day' do
@@ -13,7 +13,7 @@ class AvailabilityTest < ActiveSupport::TestCase
   end
 
   test 'correctly determines if given time is within current range' do
-    availability = FactoryGirl.build(:availability, conference: @conference)
+    availability = build(:availability, conference: @conference)
     availability.start_date = availability.day.start_date.since(1.hours)
     availability.end_date = availability.day.end_date.ago(4.hours)
     time = availability.start_date
@@ -27,7 +27,7 @@ class AvailabilityTest < ActiveSupport::TestCase
   end
 
   test 'correctly handles full day' do
-    availability = FactoryGirl.build(:availability, conference: @conference)
+    availability = build(:availability, conference: @conference)
     availability.start_date = Time.parse('00:00:00').ago(5.hours)
     availability.end_date = Time.parse('00:00:00').since(5.hours)
     time = Time.parse('00:00:00')

--- a/test/models/conference_export_test.rb
+++ b/test/models/conference_export_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ConferenceExportTest < ActiveSupport::TestCase
   test 'can create a conference export' do
-    conference_export = FactoryGirl.create :conference_export
+    conference_export = create :conference_export
     assert_not_nil conference_export.tarball
     assert File.readable? conference_export.tarball.path
     assert_not_nil conference_export.conference
@@ -11,13 +11,13 @@ class ConferenceExportTest < ActiveSupport::TestCase
 
   test 'can update a conference export attachment' do
     file = File.open(File.join(Rails.root, 'test', 'fixtures', 'tarball.tar.gz'))
-    conference_export = FactoryGirl.create :conference_export, tarball: file
+    conference_export = create :conference_export, tarball: file
     conference_export.save
     assert File.readable? conference_export.tarball.path
   end
 
   test 'can update conference export with tarball' do
-    conference = FactoryGirl.create(:three_day_conference)
+    conference = create(:three_day_conference)
     locale = 'en'
     file = File.join(Rails.root, 'test', 'fixtures', 'tarball.tar.gz')
 

--- a/test/models/conference_scrubber_test.rb
+++ b/test/models/conference_scrubber_test.rb
@@ -5,25 +5,25 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
   DUMMY_MAIL = 'root@localhost.localdomain'
 
   setup do
-    @conference = FactoryGirl.create(:conference)
+    @conference = create(:conference)
     add_day(@conference, 2.years)
     @event_person = add_event_with_speaker(@conference)
     ENV['QUIET'] = '1'
   end
 
   def add_day(conference, time)
-    conference.days << FactoryGirl.create(:day,
+    conference.days << create(:day,
       start_date: Date.today.ago(time).since(11.hours),
       end_date: Date.today.ago(time).since(23.hours))
   end
 
   def add_event_with_speaker(conference)
-    event = FactoryGirl.create(:event, conference: conference, state: 'confirmed')
-    FactoryGirl.create(:event_person, event: event)
+    event = create(:event, conference: conference, state: 'confirmed')
+    create(:event_person, event: event)
   end
 
   test 'should find last years conferences' do
-    c_new = FactoryGirl.create(:conference)
+    c_new = create(:conference)
     add_day(c_new, 1.days)
 
     @scrubber = ConferenceScrubber.new(@conference)
@@ -32,7 +32,7 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
   end
 
   test 'should recognize person active in conference' do
-    c_new = FactoryGirl.create(:conference)
+    c_new = create(:conference)
     add_day(c_new, 1.days)
     event_person = add_event_with_speaker(c_new)
 
@@ -49,7 +49,7 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
 
   test 'should clear persons contact data' do
     @scrubber = ConferenceScrubber.new(@conference)
-    person =  FactoryGirl.create(:person)
+    person =  create(:person)
     person.email_public = false
     person.phone_numbers << PhoneNumber.new
     person.im_accounts << ImAccount.new
@@ -65,7 +65,7 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
   end
 
   test 'should recognize person not active in any conference' do
-    person = FactoryGirl.create(:person)
+    person = create(:person)
     assert !person.active_in_any_conference?
   end
 
@@ -74,7 +74,7 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
   end
 
   test 'should clear persons biographical data' do
-    person =  FactoryGirl.create(:person, abstract: TEXT, description: TEXT)
+    person =  create(:person, abstract: TEXT, description: TEXT)
     @scrubber = ConferenceScrubber.new(@conference)
     @scrubber.send(:scrub_person, person)
     person.reload
@@ -84,9 +84,9 @@ class ConferenceScrubberTest < ActiveSupport::TestCase
 
   test 'should scrub all event ratings of a conference' do
     event = @event_person.event
-    FactoryGirl.create(:event_rating, event: event)
-    FactoryGirl.create(:event_rating, event: event)
-    FactoryGirl.create(:event_rating, event: event)
+    create(:event_rating, event: event)
+    create(:event_rating, event: event)
+    create(:event_rating, event: event)
 
     @scrubber = ConferenceScrubber.new(@conference)
     @scrubber.send(:scrub_event_ratings)

--- a/test/models/conference_user_test.rb
+++ b/test/models/conference_user_test.rb
@@ -2,28 +2,28 @@ require 'test_helper'
 
 class ConferenceUserTest < ActiveSupport::TestCase
   test 'create orga user' do
-    cu = FactoryGirl.create(:conference_orga)
+    cu = create(:conference_orga)
     assert_equal 1, cu.user.conference_users.size
     assert_equal 'crew', cu.user.role
     assert_equal 'orga', cu.role
   end
 
   test 'create coordinator user' do
-    cu = FactoryGirl.create(:conference_coordinator)
+    cu = create(:conference_coordinator)
     assert_equal 1, cu.user.conference_users.size
     assert_equal 'crew', cu.user.role
     assert_equal 'coordinator', cu.role
   end
 
   test 'create reviewer user' do
-    cu = FactoryGirl.create(:conference_reviewer)
+    cu = create(:conference_reviewer)
     assert_equal 1, cu.user.conference_users.size
     assert_equal 'crew', cu.user.role
     assert_equal 'reviewer', cu.role
   end
 
   test 'cannot save conference user without role' do
-    cu = FactoryGirl.create(:conference_orga)
+    cu = create(:conference_orga)
     cu.role = nil
     assert_equal false, cu.valid?
   end

--- a/test/models/conflict_test.rb
+++ b/test/models/conflict_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ConflictTest < ActiveSupport::TestCase
   test 'creates person conflict' do
-    event_person = FactoryGirl.create :event_person
+    event_person = create :event_person
     event = event_person.event
     conflict = Conflict.create(event: event, person: event_person.person, conflict_type: 'person_has_no_availability', severity: 'warning')
     assert conflict.valid?
@@ -10,8 +10,8 @@ class ConflictTest < ActiveSupport::TestCase
   end
 
   test 'creates event conflict' do
-    event = FactoryGirl.create :event
-    conflicting_event = FactoryGirl.create :event
+    event = create :event
+    conflicting_event = create :event
     conflict = Conflict.create(event: event, conflicting_event: conflicting_event, conflict_type: 'events_overlap', severity: 'fatal')
     assert conflict.valid?
     assert conflict.id

--- a/test/models/day_test.rb
+++ b/test/models/day_test.rb
@@ -2,25 +2,25 @@ require 'test_helper'
 
 class DayTest < ActiveSupport::TestCase
   test 'day label matches format' do
-    day = FactoryGirl.create(:day)
+    day = create(:day)
 
     assert_equal day.label, day.start_date.strftime('%Y-%m-%d')
   end
 
   test 'end date not possible before start date' do
-    day = FactoryGirl.create(:day)
+    day = create(:day)
     assert_equal true, day.valid?
 
     day.start_date = day.start_date.since(3.days)
     assert_equal false, day.valid?
 
-    day = FactoryGirl.create(:day)
+    day = create(:day)
     day.end_date = day.end_date.ago(2.days)
     assert_equal false, day.valid?
   end
 
   test 'day overlaps with other day' do
-    conference = FactoryGirl.create(:three_day_conference)
+    conference = create(:three_day_conference)
     conference.days[1].start_date = conference.days[0].end_date.ago(2.hours)
     assert_equal false, conference.days[1].valid?
   end

--- a/test/models/event_person_test.rb
+++ b/test/models/event_person_test.rb
@@ -2,16 +2,16 @@ require 'test_helper'
 
 class EventPersonTest < ActiveSupport::TestCase
   test "confirmation advances both person's and event's state if possible" do
-    event = FactoryGirl.create(:event, state: 'unconfirmed')
-    person = FactoryGirl.create(:person)
-    event_person = FactoryGirl.create(:event_person, event: event, person: person, role_state: 'offer')
+    event = create(:event, state: 'unconfirmed')
+    person = create(:person)
+    event_person = create(:event_person, event: event, person: person, role_state: 'offer')
     event_person.confirm!
     assert_equal 'confirmed', event_person.role_state
     assert_equal 'confirmed', event.state
   end
 
   test 'confirmation token gets generated' do
-    event_person = FactoryGirl.create(:event_person)
+    event_person = create(:event_person)
     assert_nil event_person.confirmation_token
     event_person.generate_token!
     assert_not_nil event_person.confirmation_token
@@ -19,11 +19,11 @@ class EventPersonTest < ActiveSupport::TestCase
 
   test 'checks for availability correctly' do
     today = Date.today
-    conference = FactoryGirl.create(:three_day_conference)
-    event = FactoryGirl.create(:event, conference: conference)
-    person = FactoryGirl.create(:person)
-    availability = FactoryGirl.create(:availability, conference: conference, person: person, start_date: Time.parse('10:00'), end_date: Time.parse('14:00'))
-    event_person = FactoryGirl.create(:event_person, event: event, person: person)
+    conference = create(:three_day_conference)
+    event = create(:event, conference: conference)
+    person = create(:person)
+    availability = create(:availability, conference: conference, person: person, start_date: Time.parse('10:00'), end_date: Time.parse('14:00'))
+    event_person = create(:event_person, event: event, person: person)
     assert event_person.available_between?(today.to_time.change(hour: 11), today.to_time.change(hour: 13))
     assert event_person.available_between?(today.to_time.change(hour: 10), today.to_time.change(hour: 14))
     assert !event_person.available_between?(today.to_time.change(hour: 9), today.to_time.change(hour: 11))
@@ -32,32 +32,32 @@ class EventPersonTest < ActiveSupport::TestCase
   end
 
   test 'check involved_in returns correct number of people' do
-    conference = FactoryGirl.create(:three_day_conference)
-    event = FactoryGirl.create(:event, conference: conference, state: 'confirmed')
-    person1 = FactoryGirl.create(:person)
-    person2 = FactoryGirl.create(:person)
-    event_person1 = FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
-    event_person2 = FactoryGirl.create(:event_person, event: event, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    conference = create(:three_day_conference)
+    event = create(:event, conference: conference, state: 'confirmed')
+    person1 = create(:person)
+    person2 = create(:person)
+    event_person1 = create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
+    event_person2 = create(:event_person, event: event, person: person2, event_role: 'speaker', role_state: 'confirmed')
     persons = Person.involved_in(conference)
     assert_equal 2, persons.count
     assert_includes persons, person1
 
-    FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'coordinator', role_state: 'confirmed')
+    create(:event_person, event: event, person: person1, event_role: 'coordinator', role_state: 'confirmed')
     assert_equal 2, Person.involved_in(conference).count
 
-    event2 = FactoryGirl.create(:event, conference: conference, state: 'confirmed')
-    FactoryGirl.create(:event_person, event: event2, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    event2 = create(:event, conference: conference, state: 'confirmed')
+    create(:event_person, event: event2, person: person2, event_role: 'speaker', role_state: 'confirmed')
     assert_equal 2, Person.involved_in(conference).count
   end
 
   test 'check speaking_at returns conferences speakers' do
-    conference = FactoryGirl.create(:three_day_conference_with_events)
+    conference = create(:three_day_conference_with_events)
     event = conference.events.first
-    person1 = FactoryGirl.create(:person)
-    FactoryGirl.create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
+    person1 = create(:person)
+    create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
     assert_equal 1, Person.speaking_at(conference).count
-    person2 = FactoryGirl.create(:person)
-    FactoryGirl.create(:event_person, event: event, person: person2, event_role: 'coordinator', role_state: 'confirmed')
+    person2 = create(:person)
+    create(:event_person, event: event, person: person2, event_role: 'coordinator', role_state: 'confirmed')
     assert_equal 1, Person.speaking_at(conference).count
   end
 end

--- a/test/models/event_person_test.rb
+++ b/test/models/event_person_test.rb
@@ -36,8 +36,8 @@ class EventPersonTest < ActiveSupport::TestCase
     event = create(:event, conference: conference, state: 'confirmed')
     person1 = create(:person)
     person2 = create(:person)
-    event_person1 = create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
-    event_person2 = create(:event_person, event: event, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    event_person1 = create(:confirmed_event_person, event: event, person: person1)
+    event_person2 = create(:confirmed_event_person, event: event, person: person2)
     persons = Person.involved_in(conference)
     assert_equal 2, persons.count
     assert_includes persons, person1
@@ -46,15 +46,14 @@ class EventPersonTest < ActiveSupport::TestCase
     assert_equal 2, Person.involved_in(conference).count
 
     event2 = create(:event, conference: conference, state: 'confirmed')
-    create(:event_person, event: event2, person: person2, event_role: 'speaker', role_state: 'confirmed')
+    create(:confirmed_event_person, event: event2, person: person2)
     assert_equal 2, Person.involved_in(conference).count
   end
 
   test 'check speaking_at returns conferences speakers' do
     conference = create(:three_day_conference_with_events)
     event = conference.events.first
-    person1 = create(:person)
-    create(:event_person, event: event, person: person1, event_role: 'speaker', role_state: 'confirmed')
+    create(:confirmed_event_person, event: event)
     assert_equal 1, Person.speaking_at(conference).count
     person2 = create(:person)
     create(:event_person, event: event, person: person2, event_role: 'coordinator', role_state: 'confirmed')

--- a/test/models/event_rating_test.rb
+++ b/test/models/event_rating_test.rb
@@ -2,25 +2,25 @@ require 'test_helper'
 
 class EventRatingTest < ActiveSupport::TestCase
   test 'creating ratings correctly updates average' do
-    event = FactoryGirl.create(:event)
+    event = create(:event)
     id = event.id
 
-    FactoryGirl.create(:event_rating, event: event, rating: 8.0)
+    create(:event_rating, event: event, rating: 8.0)
     update_average(id)
     assert_equal 8.0, Event.find(id).average_rating
 
-    FactoryGirl.create(:event_rating, event: event, rating: 4.0)
+    create(:event_rating, event: event, rating: 4.0)
     update_average(id)
     assert_equal 6.0, Event.find(id).average_rating
 
-    FactoryGirl.create(:event_rating, event: event, rating: 3.0)
+    create(:event_rating, event: event, rating: 3.0)
     update_average(id)
     assert_equal 5.0, Event.find(id).average_rating
   end
 
   test 'person can only submit one rating per event' do
-    event = FactoryGirl.create(:event)
-    person = FactoryGirl.create(:person)
+    event = create(:event)
+    person = create(:person)
 
     er = EventRating.new event: event, person: person, rating: 4.0
     assert er.save

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 class NotificationTest < ActiveSupport::TestCase
   setup do
-    @cfp = FactoryGirl.create(:call_for_participation)
-    FactoryGirl.create(:notification, conference: @cfp.conference, locale: 'en')
-    FactoryGirl.create(:notification, conference: @cfp.conference, locale: 'de')
+    @cfp = create(:call_for_participation)
+    create(:notification, conference: @cfp.conference, locale: 'en')
+    create(:notification, conference: @cfp.conference, locale: 'de')
     @cfp.reload
   end
 

--- a/test/models/ticket_server_test.rb
+++ b/test/models/ticket_server_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TicketServerTest < ActiveSupport::TestCase
   setup do
-    @conference = FactoryGirl.create(:conference)
+    @conference = create(:conference)
     @url = 'https://localhost/otrs/'
   end
 

--- a/test/models/ticket_test.rb
+++ b/test/models/ticket_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class TicketTest < ActiveSupport::TestCase
   setup do
-    @conference = FactoryGirl.create(:conference)
-    @event = FactoryGirl.create(:event)
+    @conference = create(:conference)
+    @event = create(:event)
   end
 
   test 'should create a ticket' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   test 'logins can be recorded' do
-    user = FactoryGirl.create(:user)
+    user = create(:user)
     assert_equal 0, user.sign_in_count
     assert_nil user.last_sign_in_at
     user.record_login!
@@ -12,12 +12,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'create admin user' do
-    user = FactoryGirl.create(:admin_user)
+    user = create(:admin_user)
     assert_equal 'admin', user.role
   end
 
   test 'create crew user' do
-    user = FactoryGirl.create(:crew_user)
+    user = create(:crew_user)
     assert_equal 'crew', user.role
   end
 end


### PR DESCRIPTION
We include FactoryGirl syntax in our `test_helper.rb`, this PR shortens all factory call builder calls.