### PR TITLE
Allow filtering event list for tracks, states and event_types

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -220,9 +220,9 @@ class EventsController < ApplicationController
 
   def search(events, params)
     filter = events
-    filter = filter.where( {state: params[:state]}) if params[:state].present?
-    filter = filter.where( {event_type: params[:type]}) if params[:type].present?
-    filter = filter.where( {track: Track.find_by(:name => params[:track_name])}) if params[:track_name].present?
+    filter = filter.where(state: params[:event_state]) if params[:event_state].present?
+    filter = filter.where(event_type: params[:event_type]) if params[:event_type].present?
+    filter = filter.where(track: Track.find_by(:name => params[:track_name])) if params[:track_name].present?
 
     if params.key?(:term) and not params[:term].empty?
       term = params[:term]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -219,6 +219,11 @@ class EventsController < ApplicationController
   end
 
   def search(events, params)
+    filter = events
+    filter = filter.where( {state: params[:state]}) if params[:state].present?
+    filter = filter.where( {event_type: params[:type]}) if params[:type].present?
+    filter = filter.where( {track: Track.find_by(:name => params[:track_name])}) if params[:track_name].present?
+
     if params.key?(:term) and not params[:term].empty?
       term = params[:term]
       sort = begin
@@ -226,7 +231,7 @@ class EventsController < ApplicationController
              rescue
                nil
              end
-      @search = events.ransack(title_cont: term,
+      @search = filter.ransack(title_cont: term,
                                description_cont: term,
                                abstract_cont: term,
                                track_name_cont: term,
@@ -234,7 +239,7 @@ class EventsController < ApplicationController
                                m: 'or',
                                s: sort)
     else
-      @search = events.ransack(params[:q])
+      @search = filter.ransack(params[:q])
     end
 
     @search.result(distinct: true)

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -1,0 +1,15 @@
+- if params[:event_type].present? or params[:event_state].present? or params[:track_name].present?
+  %p
+    %b Filters:
+    %span{:style => 'margin-left: 1em'}
+      - if params[:track_name].present?
+        = link_to "[x]", url_for(params.except(:track_name))
+        track name: #{params[:track_name]}
+    %span{:style => 'margin-left: 1em'}
+      - if params[:event_type].present?
+        = link_to "[x]", url_for(params.except(:event_type))
+        event type: #{params[:event_type]}
+    %span{:style => 'margin-left: 1em'}
+      - if params[:event_state].present?
+        = link_to "[x]", url_for(params.except(:event_state))
+        event state: #{params[:event_state]}

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -41,7 +41,7 @@
         %td= link_to event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
         %td= link_to event.event_type, url_for(params.merge({:event_type => event.event_type}))
         - if can? :crud, Event
-          %td= link_to event.state, url_for(params.merge({:state => event.state}))
+          %td= link_to event.state, url_for(params.merge({:event_state => event.state}))
         %td= l(event.created_at.to_date)
         %td.buttons
           = action_button "small", 'Show', event

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -38,10 +38,10 @@
                 = event.ticket.remote_ticket_id
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
-        %td= link_to event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
-        %td= link_to event.event_type, url_for(params.merge({:event_type => event.event_type}))
+        %td= link_to_unless params[:track_name].present?, event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
+        %td= link_to_unless params[:event_type].present?, event.event_type, url_for(params.merge({:event_type => event.event_type}))
         - if can? :crud, Event
-          %td= link_to event.state, url_for(params.merge({:event_state => event.state}))
+          %td= link_to_unless params[:event_state].present?, event.state, url_for(params.merge({:event_state => event.state}))
         %td= l(event.created_at.to_date)
         %td.buttons
           = action_button "small", 'Show', event

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -38,10 +38,10 @@
                 = event.ticket.remote_ticket_id
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
-        %td= event.track.try(:name)
-        %td= event.event_type
+        %td= link_to event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
+        %td= link_to event.event_type, url_for(params.merge({:event_type => event.event_type}))
         - if can? :crud, Event
-          %td= event.state
+          %td= link_to event.state, url_for(params.merge({:state => event.state}))
         %td= l(event.created_at.to_date)
         %td.buttons
           = action_button "small", 'Show', event

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -23,4 +23,5 @@
             papers, to allow others to submit events for
             you to review.
   - else
+    = render 'filters', params
     = render 'shared/search_and_table', collection: @events

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -12,7 +12,7 @@
     %li= link_to "Event Ratings", ratings_events_path
     - if @conference.feedback_enabled
       %li= link_to "Event Feedbacks", feedbacks_events_path
-  - if params[:term].blank? and @events.all.empty?
+  - unless @conference.events.any?
     .row
       .span16
         .blank-slate


### PR DESCRIPTION
Restrict list of displayed events to be filtered by track name, state or type allows track teams to just work on their track and still have all the search and sorting-options.