### PR TITLE
in case of an empty track, do not display a filter link

### DIFF
--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -38,7 +38,7 @@
                 = event.ticket.remote_ticket_id
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
-        %td= link_to_unless params[:track_name].present?, event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
+        %td= link_to_unless (params[:track_name].present? or event.track.nil?), event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
         %td= link_to_unless params[:event_type].present?, event.event_type, url_for(params.merge({:event_type => event.event_type}))
         - if can? :crud, Event
           %td= link_to_unless params[:event_state].present?, event.state, url_for(params.merge({:event_state => event.state}))


### PR DESCRIPTION
If no track is set, the link to the track filter would be broken.