### PR TITLE
Add support for sub-conferences

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -30,6 +30,7 @@ class ConferencesController < ApplicationController
   def new
     params.delete(:conference_acronym)
     @conference = Conference.new
+    @possible_parents = Conference.where(parent: nil)
     @first = true if Conference.count == 0
 
     respond_to do |format|
@@ -50,6 +51,10 @@ class ConferencesController < ApplicationController
   # POST /conferences
   def create
     @conference = Conference.new(conference_params)
+
+    if @conference.parent and not can? :administate, @conference.parent
+      @conference.parent = nil
+    end
 
     respond_to do |format|
       if @conference.save
@@ -122,16 +127,33 @@ class ConferencesController < ApplicationController
   end
 
   def conference_params
-    params.require(:conference).permit(
-      :acronym, :title, :timezone, :timeslot_duration, :default_timeslots, :max_timeslots, :feedback_enabled, :expenses_enabled,
+    allowed = [
+      :acronym, :title, :default_timeslots, :max_timeslots, :feedback_enabled, :expenses_enabled,
       :transport_needs_enabled, :email, :program_export_base_url, :schedule_version, :schedule_public, :color, :ticket_type,
       :event_state_visible, :schedule_custom_css, :schedule_html_intro, :default_recording_license,
-      rooms_attributes: %i(name size public rank _destroy id),
-      days_attributes: %i(start_date end_date _destroy id),
-      tracks_attributes: %i(name color _destroy id),
       languages_attributes: %i(language_id code _destroy id),
       ticket_server_attributes: %i(url user password queue _destroy id),
       notifications_attributes: %i(id locale accept_subject accept_body reject_subject reject_body _destroy)
-    )
+    ]
+
+    if @conference && @conference.new_record?
+      allowed += [ :parent_id ]
+    end
+
+    if @conference && @conference.parent.nil?
+      allowed += [
+        :timezone, :timeslot_duration,
+        days_attributes: %i(start_date end_date _destroy id),
+      ]
+    end
+
+    if @conference && (@conference.parent.nil? || can?(:adminstrate, @conference.parent))
+      allowed += [
+        rooms_attributes: %i(name size public rank _destroy id),
+        tracks_attributes: %i(name color _destroy id),
+      ]
+    end
+
+    params.require(:conference).permit(allowed)
   end
 end

--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -27,7 +27,7 @@ class Public::ScheduleController < ApplicationController
     end
     @day = @conference.days[@day_index]
 
-    @all_rooms = @conference.rooms
+    @all_rooms = @conference.rooms_including_subs
     @rooms = []
     @events = {}
     @skip_row = {}
@@ -52,7 +52,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def events
-    @events = @conference.events.is_public.confirmed.scheduled.sort { |a, b|
+    @events = @conference.events_including_subs.is_public.confirmed.scheduled.sort { |a, b|
       a.to_sortable <=> b.to_sortable
     }
     @events_by_track = @events.group_by(&:track_id)
@@ -64,8 +64,8 @@ class Public::ScheduleController < ApplicationController
   end
 
   def event
-    @event = @conference.events.is_public.confirmed.scheduled.find(params[:id])
-    @concurrent_events = @conference.events.is_public.confirmed.scheduled.where(start_time: @event.start_time)
+    @event = @conference.events_including_subs.is_public.confirmed.scheduled.find(params[:id])
+    @concurrent_events = @conference.events_including_subs.is_public.confirmed.scheduled.where(start_time: @event.start_time)
     respond_to do |format|
       format.html
       format.ics
@@ -73,7 +73,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def speakers
-    @speakers = Person.publicly_speaking_at(@conference).confirmed(@conference).order(:public_name, :first_name, :last_name)
+    @speakers = Person.publicly_speaking_at(@conference.include_subs).confirmed(@conference.include_subs).order(:public_name, :first_name, :last_name)
     respond_to do |format|
       format.html
       format.json
@@ -82,7 +82,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def speaker
-    @speaker = Person.publicly_speaking_at(@conference).confirmed(@conference).find(params[:id])
+    @speaker = Person.publicly_speaking_at(@conference.include_subs).confirmed(@conference.include_subs).find(params[:id])
   end
 
   def qrcode

--- a/app/helpers/public/schedule_helper.rb
+++ b/app/helpers/public/schedule_helper.rb
@@ -24,7 +24,7 @@ module Public::ScheduleHelper
   end
 
   def different_track_colors?
-    colors = @conference.tracks.map(&:color)
+    colors = @conference.tracks_including_subs.map(&:color)
     colors.uniq.size > 1
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,8 +12,10 @@ class Conference < ActiveRecord::Base
   has_many :conference_exports, dependent: :destroy
   has_many :mail_templates, dependent: :destroy
   has_many :transport_needs, dependent: :destroy
+  has_many :sub_conferences, class_name: Conference, foreign_key: :parent_id
   has_one :call_for_participation, dependent: :destroy
   has_one :ticket_server, dependent: :destroy
+  belongs_to :parent, class_name: Conference
 
   accepts_nested_attributes_for :rooms, reject_if: proc { |r| r['name'].blank? }, allow_destroy: true
   accepts_nested_attributes_for :days, reject_if: :all_blank, allow_destroy: true
@@ -35,6 +37,8 @@ class Conference < ActiveRecord::Base
   validates :acronym, format: { with: /\A[a-zA-Z0-9_-]*\z/ }
   validates :color, format: { with: /\A[a-zA-Z0-9]*\z/ }
   validate :days_do_not_overlap
+  validate :subs_dont_allow_days
+  validate :subs_cant_have_subs
 
   after_update :update_timeslots
 
@@ -55,6 +59,32 @@ class Conference < ActiveRecord::Base
   scope :accessible_by_orga, ->(user) {
     joins(:conference_users).where(conference_users: { user_id: user, role: 'orga' })
   }
+
+  alias :own_days :days
+
+  def days
+    if parent
+      parent.days
+    else
+      own_days
+    end
+  end
+
+  def timezone
+    if parent
+      parent.timezone
+    else
+      self.attributes['timezone']
+    end
+  end
+
+  def timeslot_duration
+    if parent
+      parent.timeslot_duration
+    else
+      self.attributes['timeslot_duration']
+    end
+  end
 
   def self.current
     self.order('created_at DESC').first
@@ -191,7 +221,7 @@ class Conference < ActiveRecord::Base
     old_duration = self.timeslot_duration_was
     factor = old_duration / self.timeslot_duration
     Event.paper_trail_off!
-    self.events.each do |event|
+    self.events_including_sub_conferences.each do |event|
       event.update_attributes(time_slots: event.time_slots * factor)
     end
     Event.paper_trail_on!
@@ -208,4 +238,25 @@ class Conference < ActiveRecord::Base
       end
     }
   end
+
+  def subs_dont_allow_days
+    if Day.where(conference: self).any? && self.parent
+      self.errors.add(:days, "are not allowed for conferences with a parent")
+      self.errors.add(:parent, "may not be set for conferences with days")
+    end
+  end
+
+  def subs_cant_have_subs
+    if self.subs.any? && self.parent
+      self.errors.add(:subs, "cannot have sub-conferences and a parent")
+      self.errors.add(:parent, "may not be set for conferences with a parent")
+    end
+  end
+
+  def duration_to_time(duration_in_minutes)
+    minutes = sprintf('%02d', duration_in_minutes % 60)
+    hours = sprintf('%02d', duration_in_minutes / 60)
+    "#{hours}:#{minutes}h"
+  end
+
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -12,7 +12,7 @@ class Conference < ActiveRecord::Base
   has_many :conference_exports, dependent: :destroy
   has_many :mail_templates, dependent: :destroy
   has_many :transport_needs, dependent: :destroy
-  has_many :sub_conferences, class_name: Conference, foreign_key: :parent_id
+  has_many :subs, class_name: Conference, foreign_key: :parent_id
   has_one :call_for_participation, dependent: :destroy
   has_one :ticket_server, dependent: :destroy
   belongs_to :parent, class_name: Conference
@@ -84,6 +84,26 @@ class Conference < ActiveRecord::Base
     else
       self.attributes['timeslot_duration']
     end
+  end
+
+  def include_subs
+    [self, self.subs].flatten.uniq
+  end
+
+  def events_including_subs
+    Event.where(conference: self.include_subs)
+  end
+
+  def rooms_including_subs
+    Room.where(conference: self.include_subs)
+  end
+
+  def tracks_including_subs
+    Track.where(conference: self.include_subs)
+  end
+
+  def languages_including_subs
+    Language.where(attachable: self.include_subs)
   end
 
   def self.current
@@ -221,7 +241,7 @@ class Conference < ActiveRecord::Base
     old_duration = self.timeslot_duration_was
     factor = old_duration / self.timeslot_duration
     Event.paper_trail_off!
-    self.events_including_sub_conferences.each do |event|
+    self.events_including_subs.each do |event|
       event.update_attributes(time_slots: event.time_slots * factor)
     end
     Event.paper_trail_on!

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,16 +38,16 @@ class Person < ActiveRecord::Base
   # validates_inclusion_of :gender, in: GENDERS, allow_nil: true
 
   scope :involved_in, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).uniq
+    joins(events: :conference).where("conferences.id": conference).uniq
   }
   scope :speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed)).uniq
+    joins(events: :conference).where("conferences.id": conference).where("event_people.event_role": %w(speaker moderator)).where("events.state": %w(unconfirmed confirmed)).uniq
   }
   scope :publicly_speaking_at, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed)).uniq
+    joins(events: :conference).where("conferences.id": conference).where("event_people.event_role": %w(speaker moderator)).where("events.public": true).where("events.state": %w(unconfirmed confirmed)).uniq
   }
   scope :confirmed, ->(conference) {
-    joins(events: :conference).where("conferences.id": conference.id).where("events.state": 'confirmed')
+    joins(events: :conference).where("conferences.id": conference).where("events.state": 'confirmed')
   }
 
   def newer_than?(person)
@@ -96,15 +96,15 @@ class Person < ActiveRecord::Base
   end
 
   def events_as_presenter_in(conference)
-    self.events.where("event_people.event_role": %w(speaker moderator), conference_id: conference.id)
+    self.events.where("event_people.event_role": %w(speaker moderator), conference: conference)
   end
 
   def events_as_presenter_not_in(conference)
-    self.events.where("event_people.event_role": %w(speaker moderator)).where('conference_id != ?', conference.id)
+    self.events.where("event_people.event_role": %w(speaker moderator)).where.not(conference: conference)
   end
 
   def public_and_accepted_events_as_speaker_in(conference)
-    self.events.is_public.accepted.where("events.state": :confirmed, "event_people.event_role": %w(speaker moderator), conference_id: conference.id)
+    self.events.is_public.accepted.where("events.state": :confirmed, "event_people.event_role": %w(speaker moderator), conference: conference)
   end
 
   def role_state(conference)
@@ -119,7 +119,7 @@ class Person < ActiveRecord::Base
   end
 
   def availabilities_in(conference)
-    availabilities = self.availabilities.where(conference_id: conference.id)
+    availabilities = self.availabilities.where(conference: conference)
     availabilities.each { |a|
       a.start_date = a.start_date.in_time_zone
       a.end_date = a.end_date.in_time_zone

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -1,16 +1,29 @@
 = simple_form_for(@conference, url: @conference.new_record? ? create_conference_path : conference_path) do |f|
+  - if @conference.new_record? && @possible_parents.any?
+    %fieldset.inputs
+      %legend= t(:parent_conference)
+      = f.input :parent_id, as: :select, collection: @possible_parents, hint: "Please select a parent for this new conference. A conferences nested under a parent will inherit the days and some settings (such as time slots and time zones etc.) from the parent, and the configuration of rooms and tracks may only be done with administation right for the parent conference. The parent's schedule export will also include events from the sub-conferences. If you don't know what this means, just leave this field blank, but note that this setting cannot be changed after the conference has been created."
+
+  - elsif @conference.parent
+    %fieldset.inputs
+      %legend= t(:parent_conference)
+      .input
+        This conference is a sub-conference of
+        ="'#{@conference.parent.title}'."
+
   %fieldset.inputs
     %legend= t(:basic_information)
     = f.input :title, hint: "The name of your conference as it shall appear throughout the site. Example: 'FrOSCon'"
     = f.input :acronym, hint: "A short and unique handle for your conference, using only lower-case letters, numbers and underscores. This will be used to identify your conference in URLs etc. Example: 'froscon2011'"
     = f.input :email, hint: "Contact email address for your conference. Will be used as reply-to address in emails sent out by the system."
     = f.input :color, hint: "You may define a color for your conference.", input_html: { class: 'color' }
-  %fieldset.inputs
-    %legend= t(:timeslot_configuration)
-    = f.input :timezone, as: :time_zone, hint: "Please select in what time zone your conference will take place. This is needed to correctly display times for your events."
-    = f.input :timeslot_duration, as: :select, collection: timeslot_durations(@conference), hint: "How long do you want the smallest timeslots to be? This essentially defines the grid on which you can plan your program. WARNING: This one is tricky and cannot be easily changed later, so give this some thought. In general, larger timeslots make things a lot simpler, but smaller ones make you more flexible. Example: If all you need is to schedule 30 minute talks that perfectly align with full and half hours, choose 30 minutes as slot size. If you have 1 hour long talks and 15 minute breaks between them, 15 minutes is the perfect slot size. Note that you can make the slot size smaller later on, as long as the old slot size is a multiple of the new one. So going from 15 minutes down to 5 is fine, while going down to 10 minutes will not work."
-    = f.input :default_timeslots, as: :select, collection: 1..20, hint: "What is the default length of your events? Example: If you chose a timeslot duration of 15 minutes to account for breaks, but your talks are usually 1 hour long, select 4, because 4 times 15 minutes is one hour."
-    = f.input :max_timeslots, as: :select, collection: 1..100, hint: "What is the maximum length of a single event (e.g. a single talk)?"
+  -if @conference.parent.nil?
+    %fieldset.inputs
+      %legend= t(:timeslot_configuration)
+      = f.input :timezone, as: :time_zone, hint: "Please select in what time zone your conference will take place. This is needed to correctly display times for your events."
+      = f.input :timeslot_duration, as: :select, collection: timeslot_durations(@conference), hint: "How long do you want the smallest timeslots to be? This essentially defines the grid on which you can plan your program. WARNING: This one is tricky and cannot be easily changed later, so give this some thought. In general, larger timeslots make things a lot simpler, but smaller ones make you more flexible. Example: If all you need is to schedule 30 minute talks that perfectly align with full and half hours, choose 30 minutes as slot size. If you have 1 hour long talks and 15 minute breaks between them, 15 minutes is the perfect slot size. Note that you can make the slot size smaller later on, as long as the old slot size is a multiple of the new one. So going from 15 minutes down to 5 is fine, while going down to 10 minutes will not work."
+      = f.input :default_timeslots, as: :select, collection: 1..20, hint: "What is the default length of your events? Example: If you chose a timeslot duration of 15 minutes to account for breaks, but your talks are usually 1 hour long, select 4, because 4 times 15 minutes is one hour."
+      = f.input :max_timeslots, as: :select, collection: 1..100, hint: "What is the maximum length of a single event (e.g. a single talk)?"
   = dynamic_association :languages, t(:event_languages), f, hint: "Choose which languages events in this conference can be held in."
   %fieldset.inputs
     %legend= t(:submission_configuration)

--- a/app/views/conferences/edit_days.html.haml
+++ b/app/views/conferences/edit_days.html.haml
@@ -3,14 +3,34 @@
     %h1= t :edit_conference_days
   = render partial: 'tabs', locals: { active: :days }
 
-  - if @conference.days.empty?
+  - if @conference.parent
     .row
       .span16
         .blank-slate
           %p
-            Here you can create and edit the conference days.
-            Your 'days' can start an end anytime, but should not
-            overlap.
-  .row
-    .span16
-      = render 'form_days'
+            The days for this conference are inherited from its
+            parent conference
+            ="'#{@conference.parent.title}'"
+            and can only be changed through the administration
+            interface of that conference.
+
+          %p
+            The currently configured days are:
+
+          %ul
+            - @conference.days.each do |day|
+              %li
+                ="#{l day.start_date} - #{l day.end_date}"
+
+  - else
+    - if @conference.days.empty?
+      .row
+        .span16
+          .blank-slate
+            %p
+              Here you can create and edit the conference days.
+              Your 'days' can start an end anytime, but should not
+              overlap.
+    .row
+      .span16
+        = render 'form_days'

--- a/app/views/conferences/edit_rooms.html.haml
+++ b/app/views/conferences/edit_rooms.html.haml
@@ -3,15 +3,33 @@
     %h1= t :edit_conference_rooms
   = render partial: 'tabs', locals: { active: :rooms }
 
-  - if @conference.rooms.empty?
+  - if @conference.parent and not can? :adminstrate, @conference.parent
     .row
       .span16
         .blank-slate
           %p
-            Here you can create and edit the rooms in which
-            your events take place. Please enter at least one
-            room. This is needed to determine the number of
-            columns in your program schedule.
-  .row
-    .span16
-      = render 'form_rooms'
+            The rooms for this conference can only be modified with
+            administration rights for the parent conference
+            ="'#{@conference.parent.title}'."
+
+          %p
+            The currently configured room are:
+
+          %ul
+            - @conference.rooms.each do |room|
+              %li
+                ="#{room.name} (size: #{room.size})"
+
+  -else
+    - if @conference.rooms.empty?
+      .row
+        .span16
+          .blank-slate
+            %p
+              Here you can create and edit the rooms in which
+              your events take place. Please enter at least one
+              room. This is needed to determine the number of
+              columns in your program schedule.
+    .row
+      .span16
+        = render 'form_rooms'

--- a/app/views/conferences/edit_tracks.html.haml
+++ b/app/views/conferences/edit_tracks.html.haml
@@ -3,22 +3,40 @@
     %h1= t :edit_conference_tracks
   = render partial: 'tabs', locals: { active: :tracks }
 
-  - if @conference.tracks.empty?
+  - if @conference.parent and not can? :adminstrate, @conference.parent
     .row
       .span16
         .blank-slate
           %p
-            If you organize your conference into different tracks,
-            this is the place to create them. Even if you do not
-            have more than one track, go ahead and enter this
-            one track.
+            The tracks for this conference can only be modified with
+            administration rights for the parent conference
+            ="'#{@conference.parent.title}'."
+
           %p
-            Tracks have a name and a color. The color is used in
-            the web based program, so feel free to customize it
-            as much as you wish.
-  .row
-    .span16
-      = render 'form_tracks'
+            The currently configured tracks are:
+
+          %ul
+            - @conference.tracks.each do |track|
+              %li
+                =track.name
+
+  - else
+    - if @conference.tracks.empty?
+      .row
+        .span16
+          .blank-slate
+            %p
+              If you organize your conference into different tracks,
+              this is the place to create them. Even if you do not
+              have more than one track, go ahead and enter this
+              one track.
+            %p
+              Tracks have a name and a color. The color is used in
+              the web based program, so feel free to customize it
+              as much as you wish.
+    .row
+      .span16
+        = render 'form_tracks'
 
 :coffeescript
   $ ->

--- a/app/views/public/schedule/day.html.haml
+++ b/app/views/public/schedule/day.html.haml
@@ -1,7 +1,7 @@
 - content_for :track_menu do
   %p.tracks Tracks:
   %ul.tracks
-    - @conference.tracks.sort_by{|e| e.name }.each do |track|
+    - @conference.tracks_including_subs.sort_by{|e| e.name }.each do |track|
       %li
         .event{class: "track-#{track.name.parameterize}", href: "\##{track.name.downcase}" }= track.name
 
@@ -55,7 +55,7 @@
                         .event-details
                           .subtitle
                             = event.subtitle
-                            - if @conference.languages.count > 1
+                            - if @conference.languages_including_subs.count > 1
                               = "(#{event.language})"
                           .speakers= event.speakers.map{|p| link_to(h(p.public_name), public_speaker_path(id: p.id))}.join(", ").html_safe
                 - else

--- a/app/views/public/schedule/event.html.haml
+++ b/app/views/public/schedule/event.html.haml
@@ -32,7 +32,7 @@
       - else
         = link_to @event.track.try(:name), public_events_path(anchor: "#{@event.track.try(:name).downcase}")
     %br/
-    - if @conference.languages.count > 1
+    - if @conference.languages_including_subs.count > 1
       %b #{t '.language'}:
       = @event.language
   %h3 #{t '.links'}:

--- a/app/views/public/schedule/events.html.haml
+++ b/app/views/public/schedule/events.html.haml
@@ -8,7 +8,7 @@
           .event{class: "track-#{track.name.parameterize}"}
             %a{href: "\##{track.name.downcase}" }= track.name
 
-- no_tracks = @conference.tracks.empty?
+- no_tracks = @conference.tracks_including_subs.empty?
 
 %h2.title= t '.events'
 

--- a/app/views/public/schedule/index.ics.ri_cal
+++ b/app/views/public/schedule/index.ics.ri_cal
@@ -1,4 +1,4 @@
-@conference.events.is_public.accepted.order(:title).each do |event|
+@conference.events_including_subs.is_public.accepted.order(:title).each do |event|
   next if event.start_time.nil?
   cal.event do |e|
     e.dtstamp = event.updated_at

--- a/app/views/public/schedule/index.json.jbuilder
+++ b/app/views/public/schedule/index.json.jbuilder
@@ -17,7 +17,7 @@ json.schedule do
       json.day_start day.start_date.iso8601
       json.day_end day.end_date.iso8601
       json.rooms do
-        @conference.rooms.each do |room|
+        @conference.rooms_including_subs.each do |room|
           json.set! room.name, room.events.is_public.accepted.scheduled_on(day).order(:start_time) do |event|
             json.id event.id
             json.guid event.guid

--- a/app/views/public/schedule/index.xcal.haml
+++ b/app/views/public/schedule/index.xcal.haml
@@ -6,7 +6,7 @@
     %x-wr-caldesc= "#{@conference.acronym} Schedule"
     %x-wr-calname= "#{@conference.acronym} Schedule"
 
-    - @conference.events.accepted.is_public.each do |event|
+    - @conference.events_including_subs.accepted.is_public.each do |event|
       - next unless event.start_time
       %vevent
         %method= "PUBLISH"

--- a/app/views/public/schedule/index.xml.haml
+++ b/app/views/public/schedule/index.xml.haml
@@ -12,7 +12,7 @@
     %timeslot_duration= duration_to_time(@conference.timeslot_duration)
   - @conference.days.each_with_index do |day, index|
     %day{index: (index + 1), date: day.start_date.strftime('%Y-%m-%d'), start: day.start_date.iso8601, end: day.end_date.iso8601}
-      - @conference.rooms.each do |room|
+      - @conference.rooms_including_subs.each do |room|
         %room{name: room.name}
           - room.events.is_public.accepted.scheduled_on(day).order(:start_time).each do |event|
             %event{id: event.id, guid: event.guid}

--- a/app/views/public/schedule/speaker.html.haml
+++ b/app/views/public/schedule/speaker.html.haml
@@ -21,7 +21,7 @@
   %h3= t '.events_in_this_conference'
   %table.list
     %tbody
-      - @speaker.public_and_accepted_events_as_speaker_in(@conference).each do |event|
+      - @speaker.public_and_accepted_events_as_speaker_in(@conference.include_subs).each do |event|
         %tr
           %td= image_box event.logo, :small
           %td= link_to event.title, public_event_path(id: event.id)

--- a/app/views/public/schedule/style.css.erb
+++ b/app/views/public/schedule/style.css.erb
@@ -39,7 +39,7 @@
   background-color: #<%= conference_bg_color -%>;
 }
 
-<% @conference.tracks.each do |track| %>
+<% @conference.tracks_including_subs.each do |track| %>
   <% if track.color.blank?
       bg_color = conference_bg_color
       fg_color = conference_fg_color

--- a/db/migrate/20160918205752_add_parent_to_conference.rb
+++ b/db/migrate/20160918205752_add_parent_to_conference.rb
@@ -1,0 +1,5 @@
+class AddParentToConference < ActiveRecord::Migration
+  def change
+    add_reference :conferences, :parent, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160515092921) do
+ActiveRecord::Schema.define(version: 20160918205752) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer  "person_id"
@@ -86,9 +86,11 @@ ActiveRecord::Schema.define(version: 20160515092921) do
     t.string   "default_recording_license", limit: 255
     t.boolean  "expenses_enabled",                          default: false,        null: false
     t.boolean  "transport_needs_enabled",                   default: false,        null: false
+    t.integer  "parent_id"
   end
 
   add_index "conferences", ["acronym"], name: "index_conferences_on_acronym"
+  add_index "conferences", ["parent_id"], name: "index_conferences_on_parent_id"
 
   create_table "conflicts", force: :cascade do |t|
     t.integer  "event_id"
@@ -162,40 +164,35 @@ ActiveRecord::Schema.define(version: 20160515092921) do
   add_index "event_ratings", ["person_id"], name: "index_event_ratings_on_person_id"
 
   create_table "events", force: :cascade do |t|
-    t.integer  "conference_id",                                                null: false
-    t.string   "title",                           limit: 255,                  null: false
-    t.string   "subtitle",                        limit: 255
-    t.string   "event_type",                      limit: 255, default: "talk"
+    t.integer  "conference_id",                                      null: false
+    t.string   "title",                 limit: 255,                  null: false
+    t.string   "subtitle",              limit: 255
+    t.string   "event_type",            limit: 255, default: "talk"
     t.integer  "time_slots"
-    t.string   "state",                           limit: 255, default: "new",  null: false
-    t.string   "language",                        limit: 255
+    t.string   "state",                 limit: 255, default: "new",  null: false
+    t.string   "language",              limit: 255
     t.datetime "start_time"
     t.text     "abstract"
     t.text     "description"
-    t.boolean  "public",                                      default: true
-    t.string   "logo_file_name",                  limit: 255
-    t.string   "logo_content_type",               limit: 255
+    t.boolean  "public",                            default: true
+    t.string   "logo_file_name",        limit: 255
+    t.string   "logo_content_type",     limit: 255
     t.integer  "logo_file_size"
     t.datetime "logo_updated_at"
     t.integer  "track_id"
     t.integer  "room_id"
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
     t.float    "average_rating"
-    t.integer  "event_ratings_count",                         default: 0
+    t.integer  "event_ratings_count",               default: 0
     t.text     "note"
     t.text     "submission_note"
-    t.integer  "speaker_count",                               default: 0
-    t.integer  "event_feedbacks_count",                       default: 0
+    t.integer  "speaker_count",                     default: 0
+    t.integer  "event_feedbacks_count",             default: 0
     t.float    "average_feedback"
-    t.string   "guid",                            limit: 255
-    t.boolean  "do_not_record",                               default: false
-    t.string   "recording_license",               limit: 255
-    t.integer  "number_of_repeats",                           default: 1
-    t.text     "other_locations"
-    t.text     "methods"
-    t.text     "target_audience_experience"
-    t.text     "target_audience_experience_text"
+    t.string   "guid",                  limit: 255
+    t.boolean  "do_not_record",                     default: false
+    t.string   "recording_license",     limit: 255
     t.text     "tech_rider"
   end
 
@@ -205,16 +202,15 @@ ActiveRecord::Schema.define(version: 20160515092921) do
   add_index "events", ["state"], name: "index_events_on_state"
 
   create_table "expenses", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",          limit: 255
     t.decimal  "value"
     t.boolean  "reimbursed"
     t.integer  "person_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.integer  "conference_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
-  add_index "expenses", ["conference_id"], name: "index_expenses_on_conference_id"
   add_index "expenses", ["person_id"], name: "index_expenses_on_person_id"
 
   create_table "im_accounts", force: :cascade do |t|
@@ -250,11 +246,11 @@ ActiveRecord::Schema.define(version: 20160515092921) do
 
   create_table "mail_templates", force: :cascade do |t|
     t.integer  "conference_id"
-    t.string   "name"
-    t.string   "subject"
+    t.string   "name",          limit: 255
+    t.string   "subject",       limit: 255
     t.text     "content"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
   end
 
   add_index "mail_templates", ["conference_id"], name: "index_mail_templates_on_conference_id"
@@ -358,12 +354,12 @@ ActiveRecord::Schema.define(version: 20160515092921) do
     t.integer  "person_id"
     t.integer  "conference_id"
     t.datetime "at"
-    t.string   "transport_type"
     t.integer  "seats"
     t.boolean  "booked"
     t.text     "note"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.string   "transport_type"
   end
 
   add_index "transport_needs", ["conference_id"], name: "index_transport_needs_on_conference_id"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -75,6 +75,22 @@ FactoryGirl.define do
     end
   end
 
+  trait :with_parent_conference do
+    after :create do |conference|
+      unless conference.subs.any?
+        conference.parent = create(:three_day_conference_with_events, title: "#{conference.title} parent")
+      end
+    end
+  end
+
+  trait :with_sub_conference do
+    after :create do |conference|
+      if conference.parent.nil?
+        create(:conference, parent: conference, title: "#{conference.title} sub")
+      end
+    end
+  end
+
   factory :user do
     person
     email { generate(:email) }
@@ -138,9 +154,11 @@ FactoryGirl.define do
     transport_needs_enabled true
     schedule_public true
     timezone 'Berlin'
+    parent nil
 
-    factory :three_day_conference, traits: [:three_days]
-    factory :three_day_conference_with_events, traits: [:three_days, :with_rooms, :with_events]
+    factory :three_day_conference, traits: [:three_days, :with_sub_conference]
+    factory :three_day_conference_with_events, traits: [:three_days, :with_rooms, :with_events, :with_sub_conference]
+    factory :sub_conference_with_events, traits: [:with_rooms, :with_events, :with_parent_conference]
   end
 
   factory :call_for_participation do

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -40,22 +40,25 @@ class ConferenceTest < ActiveSupport::TestCase
   end
 
   test '#has_submission' do
-    conference = create(:three_day_conference_with_events)
-    event = conference.events.first
-    person = create(:person)
-    create(:confirmed_event_person, event: event, person: person)
-    assert Conference.has_submission(person)
+    [:three_day_conference_with_events,
+      :sub_conference_with_events].each do |conference_type|
+      conference = create(conference_type)
+      event = conference.events.first
+      person = create(:person)
+      create(:confirmed_event_person, event: event, person: person)
+      assert Conference.has_submission(person)
 
-    conference = create(:three_day_conference_with_events)
-    event = conference.events.first
-    create(:confirmed_event_person, event: event, person: person)
-    create(:confirmed_event_person, event: event)
-    assert_equal 2, Conference.has_submission(person).count
+      conference = create(conference_type)
+      event = conference.events.first
+      create(:confirmed_event_person, event: event, person: person)
+      create(:confirmed_event_person, event: event)
+      assert_equal 2, Conference.has_submission(person).count
 
-    conference = create(:three_day_conference_with_events)
-    event = conference.events.first
-    create(:event_person, event: event, person: person, event_role: 'coordinator')
-    assert_equal 2, Conference.has_submission(person).count
+      conference = create(conference_type)
+      event = conference.events.first
+      create(:event_person, event: event, person: person, event_role: 'coordinator')
+      assert_equal 2, Conference.has_submission(person).count
+    end
   end
 
   test 'inherits from parent conference' do

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -57,4 +57,20 @@ class ConferenceTest < ActiveSupport::TestCase
     create(:event_person, event: event, person: person, event_role: 'coordinator')
     assert_equal 2, Conference.has_submission(person).count
   end
+
+  test 'inherits from parent conference' do
+    parent_conference = create(:three_day_conference_with_events)
+    sub_conference = create(:conference)
+    sub_conference.update_attributes(parent: parent_conference)
+
+    parent_conference.update_attributes(timeslot_duration: 10)
+    assert_equal sub_conference.timeslot_duration, parent_conference.timeslot_duration
+
+    parent_conference.update_attributes(timezone: "Honululu")
+    assert_equal sub_conference.timezone, parent_conference.timezone
+
+    sub_conference.days.destroy_all
+    assert_equal sub_conference.days.count, parent_conference.days.count
+  end
+
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -92,45 +92,52 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test 'event conflicts are updated if availabilities change' do
-    conference = create(:three_day_conference_with_events)
-    first_event = conference.events.first
-    assert_empty first_event.conflicts
+    [:three_day_conference_with_events,
+     :sub_conference_with_events].each do |conference_type|
+      conference = create(conference_type)
+      first_event = conference.events.first
+      assert_empty first_event.conflicts
 
-    event_person = create(:event_person, event: first_event)
-    refute_empty first_event.reload.conflicts
+      event_person = create(:event_person, event: first_event)
+      refute_empty first_event.reload.conflicts
 
-    availability = create(:availability, person: event_person.person, conference: conference,
-                                         start_date: conference.days.first.start_date,
-                                         end_date: conference.days.last.end_date)
-    assert_empty first_event.reload.conflicts
-    availability.update(start_date: conference.days.last.start_date)
-    refute_empty first_event.reload.conflicts
+      availability = create(:availability, person: event_person.person, conference: conference,
+                                           start_date: conference.days.first.start_date,
+                                           end_date: conference.days.last.end_date)
+      assert_empty first_event.reload.conflicts
+      availability.update(start_date: conference.days.last.start_date)
+      refute_empty first_event.reload.conflicts
+    end
   end
 
   test 'possible start times for event' do
-    conference = create(:three_day_conference_with_events)
-    event = conference.events.first
-    day = conference.days.first
+    [:three_day_conference_with_events,
+     :sub_conference_with_events].each do |conference_type|
+      conference = create(conference_type)
+      event = conference.events.first
+      day = conference.days.first
 
-    event_person_a = create(:event_person, event: event)
-    person_a = event_person_a.person
-    availability = create(:availability, person: person_a, conference: conference,
-                                         start_date: day.start_date,
-                                         end_date: day.start_date + 2.hours)
+      event_person_a = create(:event_person, event: event)
+      person_a = event_person_a.person
 
-    event_person_b = create(:event_person, event: event)
-    person_b = event_person_b.person
-    availability = create(:availability, person: person_b, conference: conference,
-                                         start_date: day.start_date + 1.hours,
-                                         end_date: day.start_date + 3.hours)
+      availability = create(:availability, person: person_a, conference: conference,
+                                           start_date: day.start_date,
+                                           end_date: day.start_date + 2.hours)
 
-    possible = event.possible_start_times
-    possible_days = possible.keys
-    assert possible_days.count == 1
+      event_person_b = create(:event_person, event: event)
+      person_b = event_person_b.person
+      availability = create(:availability, person: person_b, conference: conference,
+                                           start_date: day.start_date + 1.hours,
+                                           end_date: day.start_date + 3.hours)
 
-    possible_times = possible[possible_days.first]
+      possible = event.possible_start_times
+      possible_days = possible.keys
+      assert possible_days.count == 1
 
-    # 5 possible time slots, plus 1 extra for the one the event is currently scheduled on
-    assert possible_times.count == 6
+      possible_times = possible[possible_days.first]
+
+      # 5 possible time slots, plus 1 extra for the one the event is currently scheduled on
+      assert possible_times.count == 6
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for sub-conferences, so that parts of a conference can be delegated to a separate team to handle their own events, while administrators of the 'master' conference stay in control of specific details.

The implementation details are:

* Each conference gains a `parent` field to link to another conference. During the creation of a conference, all existing conferences the currently logged in user has administration rights for may be selected as parent.

* A sub-conference inherits all `days` from `parent` and may not create any `day` itself.

* The `timezone` and `timeslot_duration` attributes in sub-conferences are locked and hidden from the forms. The values are taken from `parent` instead.

* Rooms and tracks of a sub-conference may only be edited by users that have administration rights for the parent conference.

* In the public schedule of the parent conference, all events, tracks, rooms etc from all sub-conferences are taken into account for the HTML view and all machine-readable output formats. However, they don't appear in the usual work-flow in the parent conference.

