### PR TITLE
rake: make fake data generator more powerful

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -1,21 +1,80 @@
 namespace :frab do
-  desc 'add fake tracks for testing'
-  task add_fake_tracks: :environment do |_t, _args|
+
+  desc 'add fake conferences for testing'
+  task add_fake_conferences: :environment do |_t, _args|
     ActiveRecord::Base.transaction do
-      conference = Conference.all.shuffle.first
-      if not conference.present?
-        puts 'No conference exists, no new tracks created'
-      else
+      10.times do
+        name = Faker::Superhero.name
+        conference = Conference.create!(title: "#{name} Conference",
+                                        acronym: name.parameterize,
+                                        email: Faker::Internet.email,
+                                        color: Faker::Color.hex_color[1..6])
+
+        date = Faker::Time.forward(23).beginning_of_day + 9.hours
+
+        3.times do
+          conference.languages << Language.create(code: %w(en de es pt-BR).shuffle.first)
+        end
+
+        4.times do
+          day = Day.create!(start_date: date,
+                            end_date: date + 9.hours)
+
+          Person.all.each do |person|
+            next if rand(10) < 2
+
+            Availability.create!(person: person,
+                                 conference: conference,
+                                 day: day,
+                                 start_date: day.start_date + rand(4).hours,
+                                 end_date: day.end_date - rand(4).hours)
+          end
+
+          conference.days << day
+          date += 1.day
+        end
+
         5.times do
+          conference.rooms << Room.create!(conference: conference,
+                                           name: Faker::App.name,
+                                           size: Faker::Number.between(1, 50) * 25,
+                                           rank: Faker::Number.between(1, 10))
+        end
+
+        10.times do
           name = Faker::Hacker.adjective
           t = conference.tracks.where(name: name)
-          if not t.present?
-            t = Track.create!(conference: conference,
-                              name: name,
-                              color: Faker::Color.hex_color[1..6])
-            puts "Created track #{t.name}"
+          unless t.present?
+            conference.tracks << Track.create!(name: name,
+                                               color: Faker::Color.hex_color[1..6])
           end
         end
+
+        50.times do
+          event = Event.create!(conference: conference,
+                                event_type: Event::TYPES.shuffle.first,
+                                state: %w(new review withdrawn unconfirmed confirmed canceled rejected).shuffle.first,
+                                title: Faker::Book.title,
+                                subtitle: Faker::Hacker.say_something_smart.chomp('!'),
+                                abstract: Faker::Hipster.paragraph,
+                                description: Faker::Hipster.paragraph,
+                                time_slots: rand(10),
+                                track: Track.all.shuffle.first,
+                                language: conference.languages.all.shuffle.first,
+                                public: Faker::Boolean.boolean,
+                                do_not_record: Faker::Boolean.boolean,
+                                tech_rider: Faker::Hipster.words.join(", "))
+
+          5.times do
+            EventPerson.create!(person: Person.all.shuffle.first,
+                                event: event,
+                                event_role: EventPerson::ROLES.shuffle.first,
+                                role_state: EventPerson::STATES.shuffle.first,
+                                comment: Faker::Lorem.sentence)
+          end
+        end
+
+        puts "Created conference #{conference.title} (#{conference.acronym}) with #{conference.tracks.count} tracks, #{conference.days.count} days, #{conference.events.count} events"
       end
     end
   end
@@ -23,51 +82,18 @@ namespace :frab do
   desc 'add fake persons for testing'
   task add_fake_persons: :environment do |_t, _args|
     ActiveRecord::Base.transaction do
-      10.times do
+      100.times do
         p = Person.create!(email: Faker::Internet.email,
                            first_name: Faker::Name.first_name,
                            last_name: Faker::Name.last_name,
                            public_name: Faker::Internet.user_name,
-                           include_in_mailings: Faker::Boolean.boolean)
+                           include_in_mailings: Faker::Boolean.boolean,
+                           gender: ["male", "female", nil].shuffle.first)
         puts "Created person #{p.first_name} #{p.last_name} <#{p.email}> (#{p.public_name})"
       end
     end
   end
 
-  desc 'add fake events for testing'
-  task add_fake_events: :environment do |_t, _args|
-    ActiveRecord::Base.transaction do
-      conference = Conference.all.shuffle.first
-      if not conference.present?
-        puts 'No conference exists, no new events created'
-      else
-        10.times do
-          e = Event.create!(conference: conference,
-                            event_type: Event::TYPES.shuffle.first,
-                            title: Faker::Book.title,
-                            subtitle: Faker::Hacker.say_something_smart.chomp('!'),
-                            abstract: Faker::Hipster.paragraph,
-                            description: Faker::Hipster.paragraph,
-                            time_slots: rand(10),
-                            track: Track.all.shuffle.first,
-                            language: conference.languages.all.shuffle.first,
-                            public: Faker::Boolean.boolean,
-                            do_not_record: Faker::Boolean.boolean,
-                            tech_rider: Faker::Hipster.words.join(", "))
-          rand(5).times do
-            ep = EventPerson.create!(person: Person.all.shuffle.first,
-                                     event: e,
-                                     event_role: EventPerson::ROLES.shuffle.first,
-                                     role_state: EventPerson::STATES.shuffle.first,
-                                     comment: Faker::Lorem.sentence)
-          end
-
-          puts "Created event #{e.title} (#{e.subtitle}), #{e.event_people.count} event people"
-        end
-      end
-    end
-  end
-
-  desc 'add fake tracks, people and events'
-  task add_fake_data: [ :add_fake_tracks, :add_fake_persons, :add_fake_events ]
+  desc 'add fake people, confernces, events, tracks, days etc'
+  task add_fake_data: [ :add_fake_persons, :add_fake_conferences ]
 end


### PR DESCRIPTION
When a new frab instance is set up for development, it is very useful to
have some fake data to play around with. The current fake data generator
bails out if no conference was added by other means, which make it
cumbersome to populate an empty database.

Fix this by restructuring the code so it generates a bunch of new
conferences and nests new tracks, days, rooms, languages, events,
availabilities etc. under it.