### PR TITLE
Use a random password when seeding the database in production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ To start frab in the production environment run
 
     RACK_ENV=production bundle rails s
 
+Note that when seeding the database in production mode, the password for
+admin@example.org will be a random one. It will be printed to the console
+in when `rake db:seed` is invoked.
+
 ## Ticket Server
 
 frab supports OTRS, RT and Redmine ticket servers. Instead of sending

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,12 +14,16 @@ person = Person.create!(
   public_name: 'admin_127'
 )
 
+password = Rails.env.production? ? SecureRandom.urlsafe_base64(32) : 'test123'
+
 admin = User.new(
   email: person.email,
-  password: 'test123',
-  password_confirmation: 'test123'
+  password: password,
+  password_confirmation: password
 )
 admin.person = person
 admin.role = 'admin'
 admin.confirmed_at = Time.now
 admin.save!
+
+puts "Created admin user (#{admin.email}) with password #{password}"


### PR DESCRIPTION
Default passwords suck, and administrators of production machines tend to
forget to change them after the initial setup.

Use a random password when seeding the database in production
environment, but stick to 'test123' for development mode. Also print
the chosen password to the console, so people can actually log in.