### PR TITLE
Fix locale lookup broken by update in nested form

### DIFF
--- a/app/assets/javascripts/notifications.js.erb
+++ b/app/assets/javascripts/notifications.js.erb
@@ -9,7 +9,7 @@ $(function() {
     },
 
     _fetch: function(topDiv, url) {
-      var code = topDiv.find('select option:selected').text();
+      var code = topDiv.find('select').val();
       $.ajax({
         type: "GET",
         dataType: "json",

--- a/app/views/conferences/_notification_fields.html.haml
+++ b/app/views/conferences/_notification_fields.html.haml
@@ -1,4 +1,4 @@
-.nested-fields
+.nested-fields.notification
   %fieldset.inputs
     = button_tag "default text", type: 'button', class: 'btn', style: 'float:right', data: { function: 'notification-defaults', args: { url: "#{ conferences_default_notifications_path(conference_acronym: @conference.acronym) }" } }
     = f.input :locale, as: :select, collection: available_locales(@conference), hint: "Available locales for this conference and its speakers"


### PR DESCRIPTION
The DIV in nested fields gem seems to have lost the singular class name we used to identify the parent DIV containing the SELECT for locale. This broke copying default notification texts.