### PR TITLE
Default notification from state

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -213,7 +213,18 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     authorize! :update, @event
 
-    @event.event_people.presenter.each.map(&:set_default_notification)
+    case @event.
+    when 'accepting'
+      state = 'accept'
+    when 'rejecting'
+      state = 'reject'
+    when 'confirmed'
+      state = 'schedule'
+    else
+      return redirect_to(@event, alert: "Event not in a notifiable state.")
+    end
+
+    @event.event_people.presenter.each.map(&:set_default_notification(state))
 
     redirect_to edit_people_event_path(@event)
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -213,7 +213,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     authorize! :update, @event
 
-    case @event.
+    case @event.state
     when 'accepting'
       state = 'accept'
     when 'rejecting'
@@ -224,7 +224,7 @@ class EventsController < ApplicationController
       return redirect_to(@event, alert: "Event not in a notifiable state.")
     end
 
-    @event.event_people.presenter.each.map(&:set_default_notification(state))
+    @event.event_people.presenter.each{ |p| p.set_default_notification(state) }
 
     redirect_to edit_people_event_path(@event)
   end

--- a/app/models/event_person.rb
+++ b/app/models/event_person.rb
@@ -40,14 +40,14 @@ class EventPerson < ActiveRecord::Base
     availabilities.any? { |a| a.within_range?(start_time) && a.within_range?(end_time) }
   end
 
-  def set_default_notification
+  def set_default_notification(state)
     conference = self.event.conference
     locale = self.person.locale_for_mailing(conference)
     notification = conference.notifications.with_locale(locale).first
     fail "Notification for #{locale} not found" if notification.nil?
 
-    self.notification_subject = notification['accept_subject'] unless notification_subject.present?
-    self.notification_body = notification['accept_body'] unless notification_body.present?
+    self.notification_subject = notification[state+'_subject'] unless notification_subject.present?
+    self.notification_body = notification[state+'_body'] unless notification_body.present?
     save
   end
 

--- a/test/models/event_person_test.rb
+++ b/test/models/event_person_test.rb
@@ -67,7 +67,7 @@ class EventPersonTest < ActiveSupport::TestCase
 
     event_person = create(:confirmed_event_person, event: event)
     assert_raise do
-      event_person.set_default_notification
+      event_person.set_default_notification 'reject'
     end
     create(:notification, conference: conference, locale: 'en')
     assert_raise do
@@ -75,7 +75,7 @@ class EventPersonTest < ActiveSupport::TestCase
     end
 
     string = event_person.substitute_notification_variables 'accept', :subject
-    event_person.set_default_notification
+    event_person.set_default_notification 'accept'
 
     assert_not_equal event_person.substitute_notification_variables('accept', :subject), conference.rooms.first.name
     event_person.notification_subject = '%{room}'


### PR DESCRIPTION
Per EventPerson notifications were always copied from the 'accept_notification' fields. This patch makes default_notification fetch the strings from the appropriate field.