### PR TITLE
Use extra informational class to display info text, don't reuse labels

### DIFF
--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -162,3 +162,9 @@ p.availability span {
 .dl-horizontal dd {
     margin-left: 180px;
 }
+
+.info-block {
+    background-color: #ddd;
+    border-radius: 5px;
+    padding: 0.2em;
+}

--- a/app/views/conferences/edit_notifications.html.haml
+++ b/app/views/conferences/edit_notifications.html.haml
@@ -17,7 +17,7 @@
   %h1 Edit
 
   .row
-    .span6.offset8.label
+    .span6.offset8.info-block
       %h4 Possible variables
       %dl.dl-horizontal
         - Notification::VARIABLES.each do |key, desc|


### PR DESCRIPTION
The text-transform style of bootstraps .label class style was messing with how possible variables were displayed.

This patch adds a new .info-block class, adding a greyish background and round borders.