### PR TITLE
ConferencesController: set @possible_parents on failed save()

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -65,6 +65,7 @@ class ConferencesController < ApplicationController
       if @conference.save
         format.html { redirect_to(conference_home_path(conference_acronym: @conference.acronym), notice: 'Conference was successfully created.') }
       else
+        @possible_parents = Conference.where(parent: nil)
         format.html { render action: 'new' }
       end
     end


### PR DESCRIPTION
When @conference.save fails, @possible_parents must be for the 'new' view to
render correctly.

This should fix #287 