### PR TITLE
Visible indexes for days start at 1

### DIFF
--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -22,8 +22,8 @@ class Public::ScheduleController < ApplicationController
 
   def day
     @day_index = params[:day].to_i
-    if @conference.days.count <= @day_index
-      return redirect_to public_schedule_index_path, alert: "Failed to find day for id #{@day_index}"
+    if @day_index < 1 || @day_index > @conference.days.count
+      return redirect_to public_schedule_index_path, alert: "Failed to find day at index #{@day_index}"
     end
 
     setup_day_ivars
@@ -86,8 +86,7 @@ class Public::ScheduleController < ApplicationController
   end
 
   def setup_day_ivars
-    @day = @conference.days[@day_index]
-
+    @day = @conference.days[@day_index - 1]
     all_rooms = @conference.rooms_including_subs
     @rooms = []
     @events = {}

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -149,13 +149,13 @@ class Conference < ActiveRecord::Base
   end
 
   def day_at(date)
-    i = 0
+    i = 1
     days.each { |day|
       return i if date.between?(day.start_date, day.end_date)
       i += 1
     }
-    # fallback to day at index 0
-    0
+    # fallback to first day
+    1
   end
 
   def each_day(&block)

--- a/app/views/public/schedule/day.html.haml
+++ b/app/views/public/schedule/day.html.haml
@@ -7,7 +7,7 @@
 
 %h2
   - if @conference.days.length > 1
-    = t '.schedule_for_day', index: @day_index+1, label: l(@day.date)
+    = t '.schedule_for_day', index: @day_index, label: l(@day.date)
   - else
     = t '.schedule', label: l(@day.date)
 

--- a/app/views/public/schedule/index.json.jbuilder
+++ b/app/views/public/schedule/index.json.jbuilder
@@ -9,7 +9,7 @@ json.schedule do
     end
     json.daysCount @conference.days.length
     json.timeslot_duration duration_to_time(@conference.timeslot_duration)
-    index = 0
+    index = 1
     json.days @conference.days do |day|
       json.index index
       index += 1

--- a/lib/static_program_export.rb
+++ b/lib/static_program_export.rb
@@ -112,7 +112,7 @@ class StaticProgramExport
 
   def query_paths
     paths = static_query_paths
-    day_index = 0
+    day_index = 1
     @conference.days.each do |_day|
       paths << { source: "schedule/#{day_index}", target: "schedule/#{day_index}.html" }
       paths << { source: "schedule/#{day_index}.pdf", target: "schedule/#{day_index}.pdf" }

--- a/test/controllers/public/schedule_controller_test.rb
+++ b/test/controllers/public/schedule_controller_test.rb
@@ -31,17 +31,17 @@ class Public::ScheduleControllerTest < ActionController::TestCase
   end
 
   test 'displays schedule for a day' do
-    get :day, day: 0, conference_acronym: @conference.acronym
+    get :day, day: 1, conference_acronym: @conference.acronym
     assert_response :success
   end
 
   test 'displays pdf schedule for a day' do
-    get :day, day: 0, conference_acronym: @conference.acronym, format: 'pdf'
+    get :day, day: 1, conference_acronym: @conference.acronym, format: 'pdf'
     assert_response :success
   end
 
   test 'display first day' do
-    get :day, day: 0, conference_acronym: @conference.acronym, format: 'pdf'
+    get :day, day: 1, conference_acronym: @conference.acronym, format: 'pdf'
     assert_response :success
   end
 


### PR DESCRIPTION
There was some discussion about day 0 being confusing. Might be even better to add 'day' to the URL.

* Now: https://programm.froscon.org/2016/schedule/0.html
* This PR: https://programm.froscon.org/2016/schedule/1.html
* Idea: https://programm.froscon.org/2016/schedule/day/1.html

 This PR changes  the public JSON and might break external apps.