### PR TITLE
day: delete availabilities when destroyed

### DIFF
--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -2,7 +2,7 @@ class Day < ApplicationRecord
   include HumanizedDateRange
 
   belongs_to :conference
-  has_many :availabilities
+  has_many :availabilities, dependent: :destroy
 
   has_paper_trail meta: { associated_id: :conference_id, associated_type: 'Conference' }
 


### PR DESCRIPTION
When a day is destroyed, associated availabilities must be destroyed as
well. Otherwise availability.day is unresolvable afterwards.