### PR TITLE
mail templates: add a filter for speakers of all scheduled events

### DIFF
--- a/app/controllers/mail_templates_controller.rb
+++ b/app/controllers/mail_templates_controller.rb
@@ -13,7 +13,8 @@ class MailTemplatesController < BaseConferenceController
     @mail_template = @conference.mail_templates.find(params[:id])
     @send_filter_options = [
       ['All speakers involved in all confirmed events',   :all_speakers_in_confirmed_events],
-      ['All speakers involved in all unconfirmed events', :all_speakers_in_unconfirmed_events]
+      ['All speakers involved in all unconfirmed events', :all_speakers_in_unconfirmed_events],
+      ['All speakers involved in all scheduled events', :all_speakers_in_scheduled_events]
     ]
   end
 

--- a/app/jobs/send_bulk_mail_job.rb
+++ b/app/jobs/send_bulk_mail_job.rb
@@ -16,6 +16,11 @@ class SendBulkMailJob
       persons = persons
         .where('events.state': 'unconfirmed')
         .where('event_people.event_role': 'speaker')
+
+    when 'all_speakers_in_scheduled_events'
+      persons = persons
+        .where('events.state': 'scheduled')
+        .where('event_people.event_role': 'speaker')
     end
 
     persons = persons.group(:'people.id')


### PR DESCRIPTION
With the new event state in place, this filter is needed to contact all
people who are about to speak.