### PR TITLE
cfp/people: show event date and room in overview table

### DIFF
--- a/app/views/cfp/people/_table.html.haml
+++ b/app/views/cfp/people/_table.html.haml
@@ -5,6 +5,7 @@
       %th= t("activerecord.attributes.event.title")
       - if @conference.event_state_visible
         %th= t("activerecord.attributes.event.state")
+        %th= t("cfp.scheduled")
       - if @conference.feedback_enabled
         %th
         %th= t(:event_feedback)
@@ -16,12 +17,19 @@
         %td= event.title
         - if @conference.event_state_visible
           %td= event.state
-        - if @conference.feedback_enabled
           %td
-            %b= number_with_precision event.average_feedback, precision: 2
-          %td
-            - if event.event_feedbacks_count
-              s<sub>N-1</sub> = #{event.feedback_standard_deviation} n = #{event.event_feedbacks_count}
+            -if event.start_time
+              =I18n.l(event.start_time, format: :long)
+              %br
+              =event.room.name
+            -else
+              \-
+          - if @conference.feedback_enabled
+            %td
+              %b= number_with_precision event.average_feedback, precision: 2
+            %td
+              - if event.event_feedbacks_count
+                s<sub>N-1</sub> = #{event.feedback_standard_deviation} n = #{event.event_feedbacks_count}
         %td
           = link_to t("edit"), edit_cfp_event_path(event), class: "btn small"
           - if @conference.event_state_visible

--- a/config/locales/cfp.de.yml
+++ b/config/locales/cfp.de.yml
@@ -67,6 +67,7 @@ de:
     resend_confirmation_button: "Bestätigungsmail erneut versenden"
     resend_confirmation_headline: "Bestätigungsmail erneut versenden"
     save_availability: "Verfügbarkeit speichern"
+    scheduled: "Geplante Zeit"
     send_reset_instructions: "Passwortreset-Anweisungen zusenden"
     sent_password_reset_instructions: "Eine E-Mail mit Anweisen, wie Sie Ihr Passwort ändern können, wurde an Ihre E-Mailadresse gesendet."
     sign_in: "Einloggen"

--- a/config/locales/cfp.en.yml
+++ b/config/locales/cfp.en.yml
@@ -67,6 +67,7 @@ en:
     resend_confirmation_button: "Resend confirmation instructions"
     resend_confirmation_headline: "Resend confirmation instructions"
     save_availability: "Save availability"
+    scheduled: "Scheduled time"
     send_reset_instructions: "Send me reset password instructions"
     sent_password_reset_instructions: "Instructions how to reset your password have been sent to the email address you provided."
     sign_in: "Sign In"


### PR DESCRIPTION
This way, speakers can see where they are scheduled at and when.