### PR TITLE
conference: additionally order by id in ::current

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -64,7 +64,7 @@ class Conference < ActiveRecord::Base
   }
 
   def self.current
-    order('created_at DESC').first
+    order('created_at DESC, id DESC').first
   end
 
   alias own_days days


### PR DESCRIPTION
When creating multiple conference in a batch operation, chances are they
all have the same created_by attribute.

This causes the default ordering scope to return the wrong conference
through Conference.current which happens in the test cases.

Fix this by ordering by their id as well.