### PR TITLE
Fix autoload_paths to catch up the ticket_server_adapter renames

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,7 +27,7 @@ module Frab
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)
-    config.autoload_paths += %W(#{config.root}/lib/ticket_server_adapters)
+    config.autoload_paths += %W(#{config.root}/app/lib/ticket_server_adapter)
     config.autoload_paths += %W(#{config.root}/app/inputs)
 
     # Configure the default encoding used in templates for Ruby 1.9.


### PR DESCRIPTION
In commit e1c91ceac43dea2330efbea1ecff0bb119db802b, ticket server adapters were moved to app/lib/. Reflect this change in config/application.rb