### PR TITLE
Reimplement event filters, using request.query_parameters

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -239,8 +239,12 @@ class EventsController < BaseConferenceController
 
   # returns duplicates if ransack has to deal with the associated model
   def search(events)
-    @search = perform_search(events, params, %i(title_cont description_cont abstract_cont track_name_cont event_type_is))
-    if params.dig('q', 's')&.match?('track_name')
+    filter = events
+    filter = filter.where(state: params[:event_state]) if params[:event_state].present?
+    filter = filter.where(event_type: params[:event_type]) if params[:event_type].present?
+    filter = filter.where(track: @conference.tracks.find_by(:name => params[:track_name])) if params[:track_name].present?
+    @search = perform_search(filter, params, %i(title_cont description_cont abstract_cont track_name_cont event_type_is))
+    if params.dig('q', 's')&.match('track_name')
       @search.result
     else
       @search.result(distinct: true)

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -1,0 +1,15 @@
+- if params[:event_type].present? or params[:event_state].present? or params[:track_name].present?
+  %p
+    %b Filters:
+    %span{:style => 'margin-left: 1em'}
+      - if params[:track_name].present?
+        = link_to "[x]", request.query_parameters.except(:track_name)
+        track name: #{params[:track_name]}
+    %span{:style => 'margin-left: 1em'}
+      - if params[:event_type].present?
+        = link_to "[x]", request.query_parameters.except(:event_type)
+        event type: #{params[:event_type]}
+    %span{:style => 'margin-left: 1em'}
+      - if params[:event_state].present?
+        = link_to "[x]", request.query_parameters.except(:event_state)
+        event state: #{params[:event_state]}

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -38,10 +38,10 @@
                 = event.ticket.remote_ticket_id
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
-        %td= event.track.try(:name)
-        %td= event.event_type
+        %td= link_to_unless (params[:track_name].present? or event.track.nil?), event.track.try(:name), request.query_parameters.merge(:track_name => event.track.try(:name))
+        %td= link_to_unless params[:event_type].present?, event.event_type, request.query_parameters.merge(:event_type => event.event_type)
         - if policy(@conference).manage?
-          %td= event.state
+          %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
         %td= l(event.created_at.to_date)
         %td.buttons
           = action_button "small", 'Show', event

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -24,4 +24,5 @@
             papers, to allow others to submit events for
             you to review.
   - else
+    = render partial: 'filters', locals: { params: params }
     = render 'shared/search_and_table', collection: @events

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -21,6 +21,7 @@
             the "Start reviewing" button on the right, to
             rate a whole batch of events in a row.
   - else
+    = render partial: 'filters', locals: { params: params }
     .row
       .span16
         %h2 Statistics
@@ -58,10 +59,10 @@
                   = link_to event.title, event
                   %p.small
                     = by_speakers(event)
-                %td= event.track.try(:name)
-                %td= event.event_type
+                %td= link_to_unless (params[:track_name].present? or event.track.nil?), event.track.try(:name), request.query_parameters.merge(:track_name => event.track.try(:name))
+                %td= link_to_unless params[:event_type].present?, event.event_type, request.query_parameters.merge(:event_type => event.event_type)
                 - if policy(@conference).manage?
-                  %td= event.state
+                  %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
                 %td
                   - if event.average_rating
                     = raty_for("event_rating_#{event.id}", event.average_rating)


### PR DESCRIPTION
Filters were removed in 8e02785d115670ad48cada5e60af74a45741933b because url_for tried to access params, which is a too broad source for parameters. Now limit filter modifying functions to the query_parameters from request string.
