### PR TITLE
Add kqueue support for BSD systems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,12 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+require 'rbconfig'
+if RbConfig::CONFIG['target_os'] =~ /(?i-mx:bsd|dragonfly)/
+  gem 'rb-kqueue', '>= 0.2'
+end
+
+
 if ENV['CUSTOM_RUBY_VERSION']
   ruby ENV['CUSTOM_RUBY_VERSION'] # i.e.: '2.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-kqueue (0.2.5)
+      ffi (>= 0.5.0)
     redcarpet (3.4.0)
     request_store (1.3.2)
     responders (2.4.0)
@@ -391,6 +393,7 @@ DEPENDENCIES
   rails (~> 5.1.0)
   rails-controller-testing
   ransack
+  rb-kqueue (>= 0.2)
   redcarpet
   ri_cal
   roust


### PR DESCRIPTION
I do not know if the require 'rbconfig' in Gemfile is correct, but rails keeps nagging me to use kqueue under *bsd and I whole-heartedly agree that polling on BSDs is insane.