### PR TITLE
Fix a bug where submitting an event with links would silently fail

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,5 @@
 class Link < ApplicationRecord
-  belongs_to :linkable, polymorphic: true
+  belongs_to :linkable, polymorphic: true, optional: true
 
   validates :title, :url, presence: true
 

--- a/test/fixtures/textfile.txt
+++ b/test/fixtures/textfile.txt
@@ -1,0 +1,1 @@
+content

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -203,4 +203,19 @@ class EventTest < ActiveSupport::TestCase
     conference.ticket_type = 'integrated'
     assert event.notifiable
   end
+
+  test 'create with nested attributes is valid' do
+    event = build(:event)
+
+    link_plan = { 'title' => 'title value', 'url' => 'http://test.com' }
+    event.links_attributes = { 'random-string' => link_plan }
+
+    upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'textfile.txt'), 'text/plain')
+    event_attachment_plan = { 'title' => 'title value', 'attachment' => upload }
+    event.event_attachments_attributes = { 'random-string' => event_attachment_plan }
+
+    event.valid? # trigger validations
+    assert_empty event.errors.full_messages
+  end
+
 end


### PR DESCRIPTION
This change fixes a bug where creating an event with links will fail to save and reshow the form without error messages.

This is caused by `Link` validating its `linkable_id` (which is the event ID, which doesn't exist yet).