### PR TITLE
Fix 'add_fake_data' rake task

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -1,4 +1,6 @@
 namespace :frab do
+  require 'faker'
+
   desc 'add fake conferences for testing'
   task add_fake_conferences: :environment do |_t, _args|
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
Running `rake frab:add_fake_data` results in the following error (I'm using the Docker setup from #330):

```
frab@346f366a4a6e:~/app$ rake frab:add_fake_data
rake aborted!
NameError: uninitialized constant Faker
/home/frab/app/lib/tasks/fake_data.rake:87:in `block (4 levels) in <top (required)>'
/home/frab/app/lib/tasks/fake_data.rake:86:in `times'
/home/frab/app/lib/tasks/fake_data.rake:86:in `block (3 levels) in <top (required)>'
/usr/local/bundle/gems/activerecord-5.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
/usr/local/bundle/gems/activerecord-5.1.2/lib/active_record/connection_adapters/abstract/transaction.rb:194:in `block in within_new_transaction'
/usr/local/bundle/gems/activerecord-5.1.2/lib/active_record/connection_adapters/abstract/transaction.rb:191:in `within_new_transaction'
/usr/local/bundle/gems/activerecord-5.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
/usr/local/bundle/gems/activerecord-5.1.2/lib/active_record/transactions.rb:210:in `transaction'
/home/frab/app/lib/tasks/fake_data.rake:85:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => frab:add_fake_data => frab:add_fake_persons
(See full trace by running task with --trace)
```

Adding `require 'faker'`to the task fixes this.