### PR TITLE
Add an array of speaker ids to the serialization

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -91,6 +91,10 @@ class Event < ApplicationRecord
     event_people.presenter.includes(:person).all.map(&:person)
   end
 
+  def speaker_ids
+    speakers.map(&:id)
+  end
+
   def humanized_time_str
     return '' unless start_time.present?
     I18n.localize(start_time, format: :time) + I18n.t('time.time_range_seperator') + I18n.localize(end_time, format: :time)
@@ -151,7 +155,7 @@ class Event < ApplicationRecord
   end
 
   def serializable_hash(options={})
-    super(options).merge(event_classifiers: event_classifiers.map(&:as_array).to_h)
+    super(options.merge(methods: :speaker_ids)).merge(event_classifiers: event_classifiers.map(&:as_array).to_h)
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -95,6 +95,10 @@ class Event < ApplicationRecord
     speakers.map(&:id)
   end
 
+  def classifiers
+    event_classifiers.map(&:as_array).to_h
+  end
+
   def humanized_time_str
     return '' unless start_time.present?
     I18n.localize(start_time, format: :time) + I18n.t('time.time_range_seperator') + I18n.localize(end_time, format: :time)
@@ -155,7 +159,7 @@ class Event < ApplicationRecord
   end
 
   def serializable_hash(options={})
-    super(options.merge(methods: :speaker_ids)).merge(event_classifiers: event_classifiers.map(&:as_array).to_h)
+    super(options.merge(methods: [:speaker_ids, :classifiers]))
   end
 
   private

--- a/app/views/events/export.json.jbuilder
+++ b/app/views/events/export.json.jbuilder
@@ -14,4 +14,5 @@ json.array! @events do |e|
       json.extract! availibility, :start_date, :end_date, :day_id
     end
   end
+  json.classifiers e.classifiers
 end


### PR DESCRIPTION
I always found it confusing to have a speaker_count but no speakers in event's serialization. Besides manually scraping frab's HTML, I've found no way of collecting speakers for all events.

In order to process event <=> speaker associations in outside tools, the speaker id's array is included in the event's serializable_hash.