### PR TITLE
Fix jbuilder based json responses

### DIFF
--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -18,6 +18,8 @@ class Cfp::PeopleController < ApplicationController
     end
   end
 
+  # It is possbile to create person object via XML, but not to view it, that's
+  # because not all fields should be visible to the user.
   def new
     @person = Person.new(email: current_user.email)
 

--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -16,10 +16,14 @@ class Cfp::PeopleController < ApplicationController
       flash[:alert] = 'Your email address is not a valid public name, please change it.'
       redirect_to action: 'edit'
     end
+
+    respond_to do |format|
+      format.html
+    end
   end
 
-  # It is possbile to create person object via XML, but not to view it, that's
-  # because not all fields should be visible to the user.
+  # It is possbile to create a person object via XML, but not to view it.
+  # That's because not all fields should be visible to the user.
   def new
     @person = Person.new(email: current_user.email)
 

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -10,8 +10,8 @@ class ConferencesController < BaseConferenceController
     result = search
 
     respond_to do |format|
-      format.html { @conferences = result.paginate page: page_param }
-      format.json { render json: result }
+      format.html { @conferences = result.paginate(page: page_param) }
+      format.json { render template: 'conferences/index', locals: { conferences: result } }
     end
   end
 
@@ -24,9 +24,8 @@ class ConferencesController < BaseConferenceController
     @versions = PaperTrail::Version.where(conference_id: @conference.id).includes(:item).order('created_at DESC').limit(5)
 
     respond_to do |format|
-      #format.html { redirect_to(conference_crew_path(conference_acronym: @conference.acronym)) }
       format.html
-      format.json { render json: @conference }
+      format.json
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < BaseConferenceController
     respond_to do |format|
       format.html { @events = @events.paginate page: page_param }
       format.xml  { render xml: @events }
-      format.json { render json: @events }
+      format.json
     end
   end
 
@@ -102,7 +102,7 @@ class EventsController < BaseConferenceController
     respond_to do |format|
       format.html # show.html.erb
       format.xml  { render xml: @event }
-      format.json { render json: @event }
+      format.json
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < BaseConferenceController
   include Searchable
 
   # GET /events
-  # GET /events.xml
+  # GET /events.json
   def index
     authorize @conference, :read?
     @events = search @conference.events.includes(:track)
@@ -10,7 +10,6 @@ class EventsController < BaseConferenceController
     clean_events_attributes
     respond_to do |format|
       format.html { @events = @events.paginate page: page_param }
-      format.xml  { render xml: @events }
       format.json
     end
   end
@@ -94,14 +93,13 @@ class EventsController < BaseConferenceController
   end
 
   # GET /events/1
-  # GET /events/1.xml
+  # GET /events/1.json
   def show
     @event = authorize Event.find(params[:id])
 
     clean_events_attributes
     respond_to do |format|
       format.html # show.html.erb
-      format.xml  { render xml: @event }
       format.json
     end
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,13 +3,12 @@ class PeopleController < BaseConferenceController
   include Searchable
 
   # GET /people
-  # GET /people.xml
+  # GET /people.json
   def index
     @people = search Person.involved_in(@conference)
 
     respond_to do |format|
       format.html { @people = @people.paginate page: page_param }
-      format.xml  { render xml: @people }
       format.json
     end
   end
@@ -38,14 +37,13 @@ class PeopleController < BaseConferenceController
   end
 
   # GET /people/1
-  # GET /people/1.xml
+  # GET /people/1.json
   def show
     @person = authorize Person.find(params[:id])
     @view_model = PersonViewModel.new(current_user, @person, @conference)
 
     respond_to do |format|
       format.html
-      format.xml { render xml: @person }
       format.json
     end
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -10,7 +10,7 @@ class PeopleController < BaseConferenceController
     respond_to do |format|
       format.html { @people = @people.paginate page: page_param }
       format.xml  { render xml: @people }
-      format.json { render json: @people }
+      format.json
     end
   end
 
@@ -46,7 +46,7 @@ class PeopleController < BaseConferenceController
     respond_to do |format|
       format.html
       format.xml { render xml: @person }
-      format.json { render json: @person }
+      format.json
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -150,10 +150,6 @@ class Event < ApplicationRecord
     self
   end
 
-  def serializable_hash(options={})
-    super(options).merge(event_classifiers: event_classifiers.map(&:as_array).to_h)
-  end
-
   private
 
   def generate_guid

--- a/app/views/conferences/index.json.jbuilder
+++ b/app/views/conferences/index.json.jbuilder
@@ -1,3 +1,3 @@
-json.conferences @conferences do |json, conference|
-  json.partial! 'shared/event', conference: conference
+json.conferences conferences do |conference|
+  json.partial! 'shared/conference', conference: conference
 end

--- a/app/views/conferences/show.json.jbuilder
+++ b/app/views/conferences/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! 'shared/event', conference: @conference
+json.partial! 'shared/conference', conference: @conference

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.events @events do |json, event|
+json.events @events do |event|
   json.partial! 'shared/event', event: event
   json.partial! 'shared/event_admin', event: event
 end

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,4 +1,7 @@
 json.events @events do |event|
   json.partial! 'shared/event', event: event
-  json.partial! 'shared/event_admin', event: event
+  json.partial! 'shared/event_crew', event: event
+  if policy(event.conference).orga?
+    json.partial! 'shared/event_orga', event: event
+  end
 end

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,2 +1,2 @@
 json.partial! 'shared/event', event: @event
-json.partial! 'shared/event_admin', event: event
+json.partial! 'shared/event_admin', event: @event

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,2 +1,2 @@
 json.partial! 'shared/event', event: @event
-json.partial! 'shared/event_admin', event: @event
+json.partial! 'shared/event_crew', event: @event

--- a/app/views/people/index.json.jbuilder
+++ b/app/views/people/index.json.jbuilder
@@ -1,3 +1,3 @@
-json.people @people do |json, person|
+json.people @people do |person|
   json.partial! 'shared/person', person: person
 end

--- a/app/views/public/schedule/events.json.jbuilder
+++ b/app/views/public/schedule/events.json.jbuilder
@@ -2,5 +2,6 @@ json.conference_events do
   json.version @conference.schedule_version if @conference.schedule_version.present?
   json.events @view_model.events do |event|
     json.partial! 'shared/event', event: event
+    json.partial! 'shared/event_start_time', event: event
   end
 end

--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -1,9 +1,10 @@
 json.id event.id
 json.guid event.guid
 json.title event.title
+json.subtitle event.subtitle
+json.description event.description
 json.logo event.logo_path
 json.type event.event_type
-json.event_classifiers event.event_classifiers.map(&:as_array).to_h
 json.do_not_record event.do_not_record
 if event.start_time and event.room
   json.start_time event.start_time

--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -3,6 +3,7 @@ json.guid event.guid
 json.title event.title
 json.logo event.logo_path
 json.type event.event_type
+json.event_classifiers event.event_classifiers.map(&:as_array).to_h
 json.do_not_record event.do_not_record
 if event.start_time and event.room
   json.start_time event.start_time

--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -6,14 +6,6 @@ json.description event.description
 json.logo event.logo_path
 json.type event.event_type
 json.do_not_record event.do_not_record
-if event.start_time and event.room
-  json.start_time event.start_time
-  json.end_time event.end_time
-  json.room do
-    json.name event.room.name
-    json.id event.room.id
-  end
-end
 json.track event.track&.name
 json.abstract event.abstract
 json.speakers event.speakers do |person|

--- a/app/views/shared/_event_crew.json.jbuilder
+++ b/app/views/shared/_event_crew.json.jbuilder
@@ -1,5 +1,5 @@
-json.subtitle event.subtitle
 json.track event.track.try(:name)
+json.event_classifiers event.event_classifiers.map(&:as_array).to_h
 json.language event.language
 json.recording_license event.recording_license
 json.links event.links do |link|

--- a/app/views/shared/_event_orga.json.jbuilder
+++ b/app/views/shared/_event_orga.json.jbuilder
@@ -1,2 +1,3 @@
 json.speaker_ids event.speakers.map(&:id)
 json.state event.state
+json.partial! 'shared/event_start_time', event: event

--- a/app/views/shared/_event_orga.json.jbuilder
+++ b/app/views/shared/_event_orga.json.jbuilder
@@ -1,0 +1,2 @@
+json.speaker_ids event.speakers.map(&:id)
+json.state event.state

--- a/app/views/shared/_event_start_time.json.jbuilder
+++ b/app/views/shared/_event_start_time.json.jbuilder
@@ -1,0 +1,8 @@
+if event.start_time and event.room
+  json.start_time event.start_time
+  json.end_time event.end_time
+  json.room do
+    json.name event.room.name
+    json.id event.room.id
+  end
+end

--- a/test/controllers/cfp/people_controller_test.rb
+++ b/test/controllers/cfp/people_controller_test.rb
@@ -12,6 +12,15 @@ class Cfp::PeopleControllerTest < ActionController::TestCase
     @cfp_person.attributes.except('id', 'avatar_file_name', 'avatar_content_type', 'avatar_file_size', 'avatar_updated_at', 'created_at', 'updated_at', 'user_id', 'note')
   end
 
+  test 'should get show' do
+    get :show, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+
+    assert_raises ActionController::UnknownFormat do
+      get :show, format: :xml, params: { conference_acronym: @conference.acronym }
+    end
+  end
+
   test 'should get edit' do
     get :edit, params: { conference_acronym: @conference.acronym }
     assert_response :success

--- a/test/controllers/conferences_controller_test.rb
+++ b/test/controllers/conferences_controller_test.rb
@@ -29,14 +29,10 @@ class ConferencesControllerTest < ActionController::TestCase
   test 'should list all' do
     get :index
     assert_response :success
-    get :index, format: :json
-    assert_response :success
   end
 
   test 'should show conference' do
     get :show, params: { conference_acronym: @conference.acronym }
-    assert_response :success
-    get :show, format: :json, params: { conference_acronym: @conference.acronym }
     assert_response :success
   end
 
@@ -122,7 +118,24 @@ class ConferencesControllerTest < ActionController::TestCase
     end
   end
 
-  test 'get default notification texts as json' do
+  test 'should list all as JSON' do
+    get :index, format: :json
+    assert_response :success
+    conferences = JSON.parse(response.body)['conferences']
+    assert_equal 3, conferences.count
+    assert_includes conferences[0].keys, 'daysCount'
+    assert_includes conferences[0].keys, 'days'
+  end
+
+  test 'should show conference as JSON' do
+    get :show, format: :json, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+    conference = JSON.parse(response.body)
+    assert_includes conference.keys, 'daysCount'
+    assert_includes conference.keys, 'days'
+  end
+
+  test 'get default notification texts as JSON' do
     get :default_notifications, format: :json, params: { code: 'en', conference_acronym: @conference.acronym }
     assert_response :success
   end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -78,11 +78,6 @@ class EventsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'should get index as XML' do
-    get :index, format: :xml, params: { conference_acronym: @conference.acronym }
-    assert_response :success
-  end
-
   test 'should get index as JSON' do
     create(:event, conference: @conference)
     get :index, format: :json, params: { conference_acronym: @conference.acronym }
@@ -91,11 +86,6 @@ class EventsControllerTest < ActionController::TestCase
     assert_equal 2, events.count
     assert_includes events[0].keys, 'speakers'
     assert_includes events[0].keys, 'attachments'
-  end
-
-  test 'should show event as XML' do
-    get :show, format: :xml, params: { id: @event.to_param, conference_acronym: @conference.acronym }
-    assert_response :success
   end
 
   test 'should show event as JSON' do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -18,13 +18,6 @@ class EventsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:events)
   end
 
-  test 'should get index as XML/JSON' do
-    get :index, format: :xml, params: { conference_acronym: @conference.acronym }
-    assert_response :success
-    get :index, format: :json, params: { conference_acronym: @conference.acronym }
-    assert_response :success
-  end
-
   test 'should search and find a conference' do
     get :index, params: { conference_acronym: @conference.acronym, q: { s: 'acronym asc' }, term: @conference.title }
     assert_response :success
@@ -52,13 +45,6 @@ class EventsControllerTest < ActionController::TestCase
 
   test 'should show event' do
     get :show, params: { id: @event.to_param, conference_acronym: @conference.acronym }
-    assert_response :success
-  end
-
-  test 'should show event as XML/JSON' do
-    get :show, format: :xml, params: { id: @event.to_param, conference_acronym: @conference.acronym }
-    assert_response :success
-    get :show, format: :json, params: { id: @event.to_param, conference_acronym: @conference.acronym }
     assert_response :success
   end
 
@@ -92,6 +78,33 @@ class EventsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should get index as XML' do
+    get :index, format: :xml, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+  end
+
+  test 'should get index as JSON' do
+    create(:event, conference: @conference)
+    get :index, format: :json, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+    events = JSON.parse(response.body)['events']
+    assert_equal 2, events.count
+    assert_includes events[0].keys, 'speakers'
+    assert_includes events[0].keys, 'attachments'
+  end
+
+  test 'should show event as XML' do
+    get :show, format: :xml, params: { id: @event.to_param, conference_acronym: @conference.acronym }
+    assert_response :success
+  end
+
+  test 'should show event as JSON' do
+    get :show, format: :json, params: { id: @event.to_param, conference_acronym: @conference.acronym }
+    assert_response :success
+    event = JSON.parse(response.body)
+    assert_includes event.keys, 'speakers'
+  end
+
   test 'should get export accepted' do
     conference = create :three_day_conference_with_events_and_speakers
     get :export_accepted, params: { conference_acronym: conference.acronym }, format: :json
@@ -103,5 +116,7 @@ class EventsControllerTest < ActionController::TestCase
     conference = create :three_day_conference_with_events_and_speakers
     get :export_confirmed, params: { conference_acronym: conference.acronym }, format: :json
     assert_response :success
+    events = JSON.parse(response.body)
+    assert_includes events[0].keys, 'speakers'
   end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -86,6 +86,19 @@ class EventsControllerTest < ActionController::TestCase
     assert_equal 2, events.count
     assert_includes events[0].keys, 'speakers'
     assert_includes events[0].keys, 'attachments'
+    assert_includes events[0].keys, 'event_classifiers'
+    assert_includes events[0].keys, 'speaker_ids'
+    assert_includes events[0].keys, 'state'
+  end
+
+  test 'should get index as JSON for crew member' do
+    conference_user = create(:conference_reviewer, conference: @conference)
+    sign_in(conference_user.user)
+    get :index, format: :json, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+    events = JSON.parse(response.body)['events']
+    refute_includes events[0].keys, 'speaker_ids'
+    refute_includes events[0].keys, 'state'
   end
 
   test 'should show event as JSON' do

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -15,8 +15,6 @@ class PeopleControllerTest < ActionController::TestCase
     get :index, params: { conference_acronym: @conference.acronym }
     assert_response :success
     assert_not_nil assigns(:people)
-    get :index, format: :xml, params: { conference_acronym: @conference.acronym }
-    assert_response :success
   end
 
   test 'should get new' do
@@ -34,8 +32,6 @@ class PeopleControllerTest < ActionController::TestCase
 
   test 'should show person' do
     get :show, params: { id: @person.to_param, conference_acronym: @conference.acronym }
-    assert_response :success
-    get :show, format: :xml, params: { id: @person.to_param, conference_acronym: @conference.acronym }
     assert_response :success
   end
 

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PeopleControllerTest < ActionController::TestCase
   setup do
     @person = create(:person)
-    @conference = create(:conference)
+    @conference = create(:three_day_conference_with_events_and_speakers)
     login_as(:admin)
   end
 
@@ -16,8 +16,6 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:people)
     get :index, format: :xml, params: { conference_acronym: @conference.acronym }
-    assert_response :success
-    get :index, format: :json, params: { conference_acronym: @conference.acronym }
     assert_response :success
   end
 
@@ -39,8 +37,6 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :success
     get :show, format: :xml, params: { id: @person.to_param, conference_acronym: @conference.acronym }
     assert_response :success
-    get :show, format: :json, params: { id: @person.to_param, conference_acronym: @conference.acronym }
-    assert_response :success
   end
 
   test 'should get edit' do
@@ -59,5 +55,22 @@ class PeopleControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to people_path
+  end
+
+  test 'should get index as JSON' do
+    get :index, format: :json, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+    people = JSON.parse(response.body)['people']
+    assert_equal 3, people.count
+    assert_includes people[0].keys, 'full_public_name'
+    assert_includes people[0].keys, 'links'
+  end
+
+  test 'should show person as JSON' do
+    get :show, format: :json, params: { id: @person.to_param, conference_acronym: @conference.acronym }
+    assert_response :success
+    person = JSON.parse(response.body)
+    assert_includes person.keys, 'full_public_name'
+    assert_includes person.keys, 'links'
   end
 end

--- a/test/controllers/public/schedule_controller_test.rb
+++ b/test/controllers/public/schedule_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Public::ScheduleControllerTest < ActionController::TestCase
   setup do
-    @conference = create(:three_day_conference_with_events)
+    @conference = create(:three_day_conference_with_events_and_speakers)
   end
 
   test 'displays schedule main page' do
@@ -13,11 +13,16 @@ class Public::ScheduleControllerTest < ActionController::TestCase
   test 'displays xml schedule' do
     get :index, format: :xml, params: { conference_acronym: @conference.acronym }
     assert_response :success
+    schedule = Hash.from_xml(response.body)['schedule']
+    assert_includes schedule.keys, 'conference'
+    assert_includes schedule.keys, 'day'
   end
 
   test 'displays json schedule' do
     get :index, format: :json, params: { conference_acronym: @conference.acronym }
     assert_response :success
+    schedule = JSON.parse(response.body)['schedule']
+    assert_includes schedule.keys, 'conference'
   end
 
   test 'displays ical schedule' do


### PR DESCRIPTION
Probably due to updating to rails 5, the custom built
jbuilder JSON responses were no longer used.
This brings back jbuilder views and strenghtens testing around
JSON responses in the admin area.
What started as responses in different formats has now become an API
apparently.
XML responses continue to use ActiveModel::Serializer and might return
more or less fields that JSON.