### PR TITLE
Add export for speaker profile

### DIFF
--- a/app/views/cfp/people/export.html.haml
+++ b/app/views/cfp/people/export.html.haml
@@ -1,0 +1,10 @@
+%section
+  .page-header
+    %h1=t("cfp.export_profile")
+  .row
+    .span16
+      = form_tag(import_cfp_person_path, method: "post") do
+        = label_tag(:q, "Profile data:")
+        = text_area_tag(:foaf, @foaf)
+        .actions
+          = submit_tag('Import')

--- a/app/views/cfp/people/export.json.jbuilder
+++ b/app/views/cfp/people/export.json.jbuilder
@@ -1,0 +1,17 @@
+json.set! :'@context' do
+  json.name 'http://xmlns.com/foaf/0.1/name'
+  json.homepage do
+    json.set! :'@id', 'http://xmlns.com/foaf/0.1/workplaceHomepage'
+    json.set! :'@type', '@id'
+  end
+  json.Person "http://xmlns.com/foaf/0.1/Person"
+end
+
+json.set! :'@id', conference&.program_export_base_url || 'https://github.com/frab/frab'
+json.set! :'@type', 'Person'
+json.extract! person,
+  :first_name, :last_name, :public_name,
+  :email, :email_public, :include_in_mailings,
+  :gender,
+  :abstract, :description
+json.set! :avatar, Base64.encode64(Paperclip.io_adapters.for(person.avatar).read) if person.avatar.present?

--- a/app/views/shared/_navi_cfp_account.html.haml
+++ b/app/views/shared/_navi_cfp_account.html.haml
@@ -9,4 +9,11 @@
       - conferences.each do |conference|
         - unless @conference == conference
           %li= link_to conference.acronym, cfp_person_path(conference_acronym: conference.acronym)
-%li= link_to t("logout", default: "Logout"), destroy_user_session_path, method: :delete
+
+%li.dropdown
+  = link_to t('show_account', default: 'Account'), '#', class: 'dropdown-toggle'
+  %ul.dropdown-menu
+    %li= link_to t('edit_profile', default: 'Profile'), edit_cfp_person_path(current_user)
+    %li= link_to t('user_settings', default: 'Settings'), edit_cfp_user_path(current_user.person)
+    %li= link_to t('manual', default: 'Manual'), 'https://github.com/frab/frab/wiki/Manual'
+    %li= link_to t('logout', default: 'Logout'), destroy_user_session_path, method: :delete

--- a/app/views/shared/_navi_cfp_account.html.haml
+++ b/app/views/shared/_navi_cfp_account.html.haml
@@ -14,6 +14,7 @@
   = link_to t('show_account', default: 'Account'), '#', class: 'dropdown-toggle'
   %ul.dropdown-menu
     %li= link_to t('edit_profile', default: 'Profile'), edit_cfp_person_path(current_user)
+    %li= link_to t("export_profile", default: "Export profile"), export_cfp_person_path(current_user.person)
     %li= link_to t('user_settings', default: 'Settings'), edit_cfp_user_path(current_user.person)
     %li= link_to t('manual', default: 'Manual'), 'https://github.com/frab/frab/wiki/Manual'
     %li= link_to t('logout', default: 'Logout'), destroy_user_session_path, method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
       namespace :cfp do
         resource :user, except: %i(new create)
         resource :person do
+          member do
+            get :export
+            post :import
+          end
           resource :availability
         end
         get '/events/:id/confirm/:token' => 'events#confirm', as: 'event_confirm_by_token'

--- a/test/controllers/cfp/people_controller_test.rb
+++ b/test/controllers/cfp/people_controller_test.rb
@@ -30,4 +30,19 @@ class Cfp::PeopleControllerTest < ActionController::TestCase
     put :update, params: { id: @cfp_person.id, person: cfp_person_params, conference_acronym: @conference.acronym }
     assert_response :redirect
   end
+
+  test 'should show person' do
+    get :show, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+  end
+
+  test 'should export person' do
+    get :export, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+  end
+
+  test 'should import person' do
+    post :import, params: { conference_acronym: @conference.acronym, foaf: { first_name: 'fake-name' }.to_json }
+    assert_response :redirect
+  end
 end

--- a/test/features/export_profile_test.rb
+++ b/test/features/export_profile_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ExportProfileTest < FeatureTest
+  setup do
+    @conference = create(:three_day_conference_with_events)
+    @event = @conference.events.last
+    create(:call_for_participation, conference: @conference)
+
+    @user = create(:cfp_user)
+    create(:event_person, event: @event, person: @user.person, role_state: 'confirmed')
+
+    sign_in_user(@user)
+    click_on 'Participate'
+  end
+
+  test 'export profile' do
+    click_on 'Account'
+    click_on 'Export profile'
+    assert_content page, 'Export profile'
+  end
+end


### PR DESCRIPTION
This implements #341 
The speaker can copy and paste  JSON to another frab instance to copy name, abstract, description and some settings. The speaker logo is not included.