### PR TITLE
Group conference roles of crew users (implements #352)

### DIFF
--- a/app/controllers/conference_users_controller.rb
+++ b/app/controllers/conference_users_controller.rb
@@ -1,20 +1,13 @@
 class ConferenceUsersController < BaseCrewController
   def index
-    @users = policy_scope(ConferenceUser.all).order(:user_id, :role, :conference_id).paginate(page: page_param)
+    @users = policy_scope(ConferenceUser.all)
+      .includes(user: :person)
+      .order(:user_id, :role, :conference_id)
+      .paginate(page: page_param)
   end
 
   def admins
     authorize User, :index?
     @users = User.all_admins.order(:email).paginate(page: page_param)
-  end
-
-  def destroy
-    conference_user = authorize ConferenceUser.find(params[:id])
-
-    conference_user.destroy
-
-    respond_to do |format|
-      format.html { redirect_to(conference_users_path) }
-    end
   end
 end

--- a/app/views/conference_users/_table.html.haml
+++ b/app/views/conference_users/_table.html.haml
@@ -6,14 +6,13 @@
     %th= t('activerecord.attributes.conference_user.role')
     %th= t(:actions)
   %tbody
-    - collection.each do |conference_user|
+    - collection.group_by { |cu| cu.user_id }.each do |user_id, conference_users|
+      - conference_user = conference_users.first
       %tr
         %td
         %td= conference_user.user.email
-        %td= conference_user.conference.acronym
-        %td= conference_user.role
+        %td= conference_users.map { |cu| "#{cu.conference.acronym}=#{cu.role}" }.join(', ')
+        %td= conference_users.map(&:role).max_by { |r|  ConferenceUser::ROLES.index(r) }
         %td
           - if policy(conference_user).edit?
             = action_button 'small danger', t('edit'), edit_person_user_path(conference_user.user.person, conference_acronym: conference_user.conference.acronym)
-          - if policy(conference_user).destroy?
-            = action_button 'small danger', t('destroy'), conference_users_path(person_id: conference_user.user.person), data: { confirm: 'Are you sure' }, method: :delete

--- a/test/controllers/conference_users_controller_test.rb
+++ b/test/controllers/conference_users_controller_test.rb
@@ -13,9 +13,8 @@ class ConferenceUsersControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'should get destroy' do
-    delete :destroy, params: { id: @conference_user }
-    assert_response :redirect
-    assert_equal 2, ConferenceUser.count
+  test 'should get admins' do
+    get :admins
+    assert_response :success
   end
 end


### PR DESCRIPTION
This also removes the destroy conference_user button, crew roles
can still be removed from the edit user page.