### PR TITLE
346: Adding in the correct separator for datetime format

### DIFF
--- a/app/views/conferences/_day_fields.html.haml
+++ b/app/views/conferences/_day_fields.html.haml
@@ -1,7 +1,7 @@
 .nested-fields
   %fieldset.inputs
-    = f.input :start_date, html5: true, hint: "yyyy-mm-dd hh:mm", as: :datetime, input_html: { value: f.object.start_date.try(:strftime, '%Y-%m-%d %H:%M') }
-    = f.input :end_date, html5: true, hint: "yyyy-mm-dd hh:mm", as: :datetime, input_html: { value: f.object.end_date.try(:strftime, '%Y-%m-%d %H:%M') }
+    = f.input :start_date, html5: true, hint: "yyyy-mm-dd hh:mm", as: :datetime, input_html: { value: f.object.start_date.try(:strftime, '%Y-%m-%dT%H:%M') }
+    = f.input :end_date, html5: true, hint: "yyyy-mm-dd hh:mm", as: :datetime, input_html: { value: f.object.end_date.try(:strftime, '%Y-%m-%dT%H:%M') }
 
     = remove_association_link :day, f
 
@@ -9,7 +9,8 @@
   $(function() {
     $('div.datetime input').datetimepicker({
       dateFormat: "yy-mm-dd",
-      timeFormat: "HH:mm",
+      timeFormat: "HH:mm:ss",
+      separator: "T",
       stepHour: 1,
       stepMinute: #{@conference.timeslot_duration}
     });

--- a/app/views/shared/_transport_needs_form.html.haml
+++ b/app/views/shared/_transport_needs_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for [person, transport_need] do |f|
   %fieldset.inputs
-    = f.input :at, html5: true, as: :datetime, hint: "yyyy-mm-dd hh:mm", input_html: { value: f.object.at.try(:strftime, '%Y-%m-%d %H:%M') }
+    = f.input :at, html5: true, as: :datetime, hint: "yyyy-mm-dd hh:mm", input_html: { value: f.object.at.try(:strftime, '%Y-%m-%dT%H:%M') }
     = f.input :transport_type, as: :select, collection: TransportNeed::TYPES, hint: "What type of transportation is needed?"
     = f.input :seats, hint: "How many seats are needed?"
     = f.input :booked, as: :inline_boolean, hint: "Has this transportation been booked?"
@@ -13,6 +13,7 @@
   $(function() {
     $('div.datetime input').datetimepicker({
         dateFormat: "yy-mm-dd",
-        timeFormat: "HH:mm"
+        timeFormat: "HH:mm",
+        separator: "T"
     });
   })


### PR DESCRIPTION
Fixes: https://github.com/frab/frab/issues/346

## Approach: 
 When I first started investigating this bug I noticed that when I reviewed the console when trying to set the date I was seeing the following warning in the console:
```
The specified value "2017-10-18 00:00:00" does not conform to the required format.  The format is "yyyy-MM-ddThh:mm" followed by optional ":ss" or ":ss.SSS".
```
 The issue here seemed to be the space that separated the date was supposed to be a T... This is true both in the value that was being sent from the datetimepicker and the format used when installing the value from the db into the input box.

I fixed both formats for the datetimepicker and the inputs from the server.

## Notes:
I found this same issue with the transport needs form and fixed it there as well.