### PR TITLE
Fix short events lack text in PDF schedule

### DIFF
--- a/app/views/schedule/custom_pdf.pdf.prawn
+++ b/app/views/schedule/custom_pdf.pdf.prawn
@@ -82,7 +82,7 @@ prawn_document(
       coord = [0, y]
       pdf.bounding_box(coord,
                        width: @layout.margin_width - 1,
-                       height: event.time_slots * timeslot_height - 1) do
+                       height: (event.time_slots == 0 ? timeslot_height : event.time_slots * timeslot_height - 1)) do
         pdf.rounded_rectangle(pdf.bounds.top_left, pdf.bounds.width, pdf.bounds.height, 3)
         pdf.fill_color = 'ffffff'
         pdf.fill_and_stroke
@@ -98,7 +98,7 @@ prawn_document(
         coord = event_coordinates(i, event, column_width, timeslot_height, offset)
         pdf.bounding_box(coord,
                          width: column_width - 1,
-                         height: event.time_slots * timeslot_height - 1) do
+                         height: (event.time_slots == 0 ? timeslot_height : event.time_slots * timeslot_height - 1)) do
           pdf.rounded_rectangle pdf.bounds.top_left, pdf.bounds.width, pdf.bounds.height, 3
           pdf.fill_color = 'ffffff'
           pdf.fill_and_stroke


### PR DESCRIPTION
This should fix #328 

Events with duration of 0 minutes will actually take as much space as 15 minutes event so name and people can be displayed.

I just updated calculation of box height. Please correct me if I understand it wrong.
Here is sample result for this change:

<img width="948" alt="frab_pdf_schedule_events_fixed" src="https://user-images.githubusercontent.com/7894868/31856252-a1e4da06-b6bc-11e7-89c7-e5fce998a68d.png">
