### PR TITLE
Use gravatar as default avatar for a Person

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person < ApplicationRecord
   GENDERS = %w(male female other).freeze
+  DEFAULT_AVATAR_SIZE = '32'.freeze
 
   has_many :availabilities, dependent: :destroy
   has_many :event_people, dependent: :destroy
@@ -29,7 +30,14 @@ class Person < ApplicationRecord
 
   has_attached_file :avatar,
     styles: { tiny: '16x16>', small: '32x32>', large: '128x128>' },
-    default_url: 'person_:style.png'
+    default_url: ':default_avatar_url',
+    escape_url: false
+
+  Paperclip.interpolates :default_avatar_url do |avatar, style|
+    style = :small if style.blank? || style.eql?(:original)
+
+    avatar.instance.default_avatar_url(style)
+  end
 
   validates_attachment_content_type :avatar, content_type: [/jpg/, /jpeg/, /png/, /gif/]
 
@@ -193,9 +201,23 @@ class Person < ApplicationRecord
     MergePersons.new(keep_last_updated).combine!(self, doppelgaenger)
   end
 
+  def default_avatar_url(style = :small)
+    return "person_#{style}.png" unless email
+
+    # size is of the format '32x32>' string
+    size = avatar.styles[style][:geometry]
+
+    width = size.split('x').first
+    gravatar_url(width)
+  end
+
   private
 
   def nilify_empty
     self.gender = nil if gender and gender.empty?
+  end
+
+  def gravatar_url(width = DEFAULT_AVATAR_SIZE)
+    "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email)}?size=#{width}&dd=mm"
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -57,6 +57,18 @@ class PersonTest < ActiveSupport::TestCase
     assert_nil event_person2.reload.role_state
   end
 
+  test '#default_avatar_url' do
+    person_without_email = build(:person, email: nil)
+
+    assert_equal 'person_small.png', person_without_email.default_avatar_url
+
+    person_with_email = build(:person, email: 'abc@xyz.org')
+    email_md5 = Digest::MD5.hexdigest('abc@xyz.org')
+    gravatar = "https://www.gravatar.com/avatar/#{email_md5}?size=32&dd=mm"
+
+    assert_equal gravatar, person_with_email.default_avatar_url
+  end
+
   test 'feedback average gets calculated correctly' do
     conference = create(:conference)
     event1 = create(:event, conference: conference)
@@ -135,5 +147,13 @@ class PersonTest < ActiveSupport::TestCase
 
     assert_equal merged_person, person3
     assert_equal 'orga', person3.user.conference_users.find_by(conference_id: conference1.id).role
+  end
+
+  test 'default avatar is gravatar' do
+    person = create(:person)
+    email_md5 = Digest::MD5.hexdigest(person.email)
+    gravatar = "https://www.gravatar.com/avatar/#{email_md5}?size=32&dd=mm"
+
+    assert_equal gravatar, person.avatar.url
   end
 end


### PR DESCRIPTION
When no avatar is uploaded for a person, then default it to Gravatar
Implements https://en.gravatar.com/site/implement/images/

Fixes #244 