### PR TITLE
Need post to confirm

### DIFF
--- a/app/controllers/cfp/events_controller.rb
+++ b/app/controllers/cfp/events_controller.rb
@@ -81,11 +81,14 @@ class Cfp::EventsController < ApplicationController
   end
 
   def confirm
-    event_people = event_people_from_params
-    if event_people.blank?
+    @event_people = event_people_from_params
+    if @event_people.blank?
       return redirect_to cfp_person_path, flash: { error: t('cfp.no_confirmation_token') }
     end
-    event_people.each(&:confirm!)
+    @event = @event_people.first.event
+    return unless request.post?
+
+    @event_people.each(&:confirm!)
 
     if current_user
       redirect_to cfp_person_path, notice: t('cfp.thanks_for_confirmation')

--- a/app/views/cfp/events/confirm.html.haml
+++ b/app/views/cfp/events/confirm.html.haml
@@ -1,8 +1,9 @@
 %section
   .page-header
-    %h1=t("cfp.event_confirmed")
-  .row
-    .span16
-      = render "shared/flash", flash: flash
+    %h1 Confirm your attendance
+    = form_tag request.url do
       %p
-        = t("cfp.thanks_for_confirmation")
+        Your confirmation is required for the event
+        %b=@event.title
+      = submit_tag "Confirm attendance", class: 'btn btn-large btn-primary'
+

--- a/config/locales/cfp.de.yml
+++ b/config/locales/cfp.de.yml
@@ -9,6 +9,8 @@ de:
     change_password_headline: "Passwort ändern"
     classifiers_hint: "Durch 'classifier' können Sie der Veranstaltungs-Organisation und Ihrem Publikum helfen, die Einreichung besser einzuordnen. Wählen Sie die zutreffenden Kategorien für Ihre Einreichung und wichten Sie sie mithilfe der Slider."
     confirm: "bestätigen"
+    confirm_attendance: "Teilnahme bestätigen"
+    confirm_attendance_explanation: "Bitte bestätigen Sie Ihre Teilnahme am Vortrag "
     confirmation_button: "Bestätigungsmail erneut anfordern"
     confirmation_description: "Gelegentlich kann eine E-Mail nicht zugestellt werden. Wenn Sie bereits einige Zeit warten und auch schon Ihrem Spam-Ordner überprüft haben, klicken Sie bitten hier:"
     confirmation_headline: "Ich bin bereits registriert, habe aber keine Bestätigungsmail erhalten"

--- a/config/locales/cfp.en.yml
+++ b/config/locales/cfp.en.yml
@@ -10,6 +10,8 @@ en:
     classifiers_hint: "Help your audience and reviewers to understand your submission. Choose and then weight the appropriate categories for your submission."
     conference_in_the_past: "You can't submit a talk, because this conference is in the past."
     confirm: "confirm"
+    confirm_attendance: "Confirm attendance"
+    confirm_attendance_explanation: "Please click the button to re-confirm that you will be speaking at the event"
     confirmation_button: "Request the confirmation instructions again"
     confirmation_description: "This could be one of the rare occassions where an email has actually not been delivered. If you have already waited for some time and checked your spam folders, please"
     confirmation_headline: "I have registered but not received my confirmation instructions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
           end
           resource :availability
         end
-        get '/events/:id/confirm/:token' => 'events#confirm', as: 'event_confirm_by_token'
+        match '/events/:id/confirm/:token' => 'events#confirm', as: 'event_confirm_by_token', via: [:get, :post]
         get '/events/join(/:token)' => 'events#join', as: :events_join
         post '/events/join/:token' => 'events#join'
         get '/schedule' => 'schedule#index', as: 'schedule'


### PR DESCRIPTION
Let presenters land on a confirm page that has a "confirm" button, if confirmation is sent via GET. Fixes #371 .