### PR TITLE
Do not set a coordinator on transitions, if one is already set

### DIFF
--- a/app/models/concerns/event_state.rb
+++ b/app/models/concerns/event_state.rb
@@ -66,7 +66,7 @@ module EventState
       end
     end
     return unless options[:coordinator]
-    return if event_people.find_by(person_id: options[:coordinator].id, event_role: 'coordinator')
+    return if event_people.find_by(event_role: 'coordinator')
     event_people.create(person: options[:coordinator], event_role: 'coordinator')
   end
 
@@ -77,7 +77,7 @@ module EventState
       end
     end
     return unless options[:coordinator]
-    return if event_people.find_by(person_id: options[:coordinator].id, event_role: 'coordinator')
+    return if event_people.find_by(event_role: 'coordinator')
     event_people.create(person: options[:coordinator], event_role: 'coordinator')
   end
 


### PR DESCRIPTION
An event normally has only one coordinator, so automatically setting one on state transitions yields two, if a coordinator has already been designated. (I learnt that the hard way when my scripting user became coordinator for 150 lectures in a single run.)

This change will only create a coordinator if none is set.