### PR TITLE
state transition check fails if tested against a string, not a symbol

### DIFF
--- a/app/models/concerns/event_state.rb
+++ b/app/models/concerns/event_state.rb
@@ -46,7 +46,7 @@ module EventState
   end
 
   def transition_possible?(transition)
-    self.class.state_machine.events_for(current_state).include?(transition)
+    self.class.state_machine.events_for(current_state).include?(transition.to_sym)
   end
 
   def notifiable


### PR DESCRIPTION
If taken from a parameter, the test
  def transition_possible?(transition)
executed from
  app/controllers/events_controller.rb
in
    return redirect_to(@event, alert: 'Cannot update state.') unless @event.transition_possible?(params[:transition])
always fails. Fixing it by converting the string to a symbol before inclusion check.