### PR TITLE
Preview track color in conference schedule

### DIFF
--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -92,6 +92,14 @@ div.event {
   padding: 3px;
 }
 
+div.color-preview {
+  width: 1em;
+  height: 1em;
+  border: 1px solid #808080;
+  float: left;
+  margin: .5ex 1ex .5ex .5ex;
+}
+
 div.event.fatal {
   background: #EE3333;
 }

--- a/app/views/cfp/schedule/_event.html.haml
+++ b/app/views/cfp/schedule/_event.html.haml
@@ -4,6 +4,7 @@
         :"data-update-url" => cfp_schedule_update_event_path(id: event.id),
         :"data-room" => event.room ? event.room.name.downcase : nil,
         :"data-time" => event.start_time ? event.start_time.to_s(:rfc822) : nil }
+  .color-preview{ style: "background-color: ##{event.track.try(:color)}" }
   = event.title
   %p.small
     = by_speakers(event)

--- a/app/views/schedule/_event.html.haml
+++ b/app/views/schedule/_event.html.haml
@@ -4,6 +4,7 @@
         :"data-update-url" => schedule_update_event_path(id: event.id),
         :"data-room" => event.room ? event.room.name.downcase : nil,
         :"data-time" => event.start_time ? event.start_time.to_s(:rfc822) : nil }
+  .color-preview{ style: "background-color: ##{event.track.try(:color)}" }
   = link_to event.title, event
   %p.small
     = by_speakers(event)


### PR DESCRIPTION
The conference schedule page (not the public one) displays events using green, orange and red as background color depending the event having conflicts or other conditions to look after for organizers.

The track color is not visible to organizers from this screen, which was requested by our customer.

This Pull-Request add a small square that previews the event's track color as shown bellow:

![Preview](https://screenshots.firefoxusercontent.com/images/5f5a5c0a-56a5-40df-bc30-1f0be7f07110.png) 