### PR TITLE
allow coordinators to preview the schedule

### DIFF
--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -101,7 +101,7 @@ class Public::ScheduleController < ApplicationController
   def maybe_authenticate_user!
     return if @conference.schedule_public
     authenticate_user!
-    orga_only!
+    manage_only!
   end
 
   private


### PR DESCRIPTION
The have access to the schedule anyway. I would even go one step further and allow the reviewers (method crew_only) to access the preview, but this might require further discussion...