### PR TITLE
Fix missing variable in events/people view

### DIFF
--- a/app/views/events/people.html.haml
+++ b/app/views/events/people.html.haml
@@ -1,7 +1,7 @@
 %section
   .page-header
     .pull-right
-      = action_button "primary", t('edit'), edit_people_event_path(@event), hint: t('titles.edit_people_for_event')
+      = action_button "primary", t('edit'), edit_people_event_path(@event), hint: t('titles.edit_people_for_event', {event: @event.title})
     %h1= t('titles.event', {event: @event.title})
   = render 'shared/events_tabs'
   - if @event.event_people.count == 0


### PR DESCRIPTION
Affected translation expects a `event.title` variable.
This commit add this missing variable.