### PR TITLE
Fix translation keyword in events view

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -62,7 +62,7 @@
         %b= t('avg_audience_feedback')
         = number_with_precision @event.average_feedback, precision: 1
     .span6
-      %h2= EventPerson.model_name.human(count: 2)
+      %h2= t('people')
       %p= @event.speakers.map{ |p| link_to p.public_name, p}.join(", ").html_safe
       %h2= t('scheduling')
       %p


### PR DESCRIPTION
IMHO, we could improve this title using "Involved persons" or something similar, but at least this commit fixes the current situation.