### PR TITLE
Fix typo in "address" word

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,7 +83,7 @@ en:
         reimbursed: Reimbursed
         value: Value
       im_account:
-        im_adress: Address
+        im_address: Address
         im_type: IM Type
       langage:
         code: Code
@@ -663,7 +663,7 @@ en:
         headline: Welcome %{email} !
         link: Confirm my account
         subject: Confirmation instructions
-        text: 'You should confirm your email adress with the following link:
+        text: 'You should confirm your email address with the following link:
 
 '
       email_change:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -95,7 +95,7 @@ fr:
         reimbursed: Remboursée
         value: Montant
       im_account:
-        im_adress: Adresse
+        im_address: Adresse
         im_type: Type
       langage:
         code: Langue


### PR DESCRIPTION
Please note that even `im_address` keywords were incorrect in EN and FR language files, there are correct in other languages and in source code.