### PR TITLE
Add keyword to translate 'by'

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,7 +107,7 @@ module ApplicationHelper
   def by_speakers(event)
     speakers = event.speakers.map { |p| link_to(p.public_name, p) }
     if speakers.present?
-      'by '.html_safe + safe_join(speakers, ', ')
+      (t('by') + ' ').html_safe + safe_join(speakers, ', ')
     else
       ''
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,7 @@ en:
   availability: Availability
   available: Available
   basic_information: Basic informations
+  by: by
   call_for_participation: Call for Participation
   cancel: Cancel
   cfp:


### PR DESCRIPTION
This commit allow to translate the word 'by' used in helpers.

Please note that this commit do not change the behavior in EN nor add translations.