### PR TITLE
Fix translation keyword in people view

### DIFF
--- a/app/views/events/people.html.haml
+++ b/app/views/events/people.html.haml
@@ -8,7 +8,7 @@
     .row
       .span16
         .blank-slate
-          %p=raw(GitHub::Markdown.render(t('people_module.no_people_in event')))
+          %p=raw(GitHub::Markdown.render(t('people_module.no_people_in_event')))
 
   - else
     .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1705,13 +1705,6 @@ en:
         person_filter: |
           Filter persons in the options menu below by their first name, last
           name, email address or user ID. Leave blank for no filtering."
-      no_people_in event: |
-        There are no people associated with this event yet.
-        Use the button on the right to add people. Please
-        note that you can only add people that are already
-        in the system. If the person you would like to add
-        is not yet in the system, go to the _People_
-        tab above and create this person first.
       notification_body: Notification body
       notification_subject: Notification subject
     list_of_people: List of people
@@ -1725,6 +1718,13 @@ en:
       There are no people associated with this conference yet. People will
       start appearing here, once they take on a role in any of this
       conference's events.
+    no_people_in_event: |
+      There are no people associated with this event yet.
+      Use the button on the right to add people. Please
+      note that you can only add people that are already
+      in the system. If the person you would like to add
+      is not yet in the system, go to the _People_
+      tab above and create this person first.
     no_user_account: Person has no user account yet and cannot login. Click on the user tab to create an account.
     no_user_account_for_person: |
       %{person} does not currently have a user account and thus cannot login.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1760,12 +1760,6 @@ fr:
         person_filter: |
           Filtrez les personnes par nom, prénom, adresse email ou id. Laissez vide
           pour enlever les filtres.
-      no_people_in event: |
-        Il n'y a pas de personne associée à cet évènement pour le moment.
-        Utilisez le bouton sur la droite pour en ajouter. Notez que vous
-        pouvez seulement ajouter des personnes qui sont déjà présentes dans le
-        système. Si vous voulez ajouter quelqu'un qui n'est pas encore dedans,
-        allez sur l'onglet _Personnes_ et créez cette personne en premier.
       notification_body: Notification body
       notification_subject: Notification subject
     list_of_people: Liste des personnes
@@ -1780,6 +1774,12 @@ fr:
       Il n'y a pas de personne associée à cette conférence pour le moment.
       Les gens vont commencer à apparître ici dès qu'ils auront pris un rôle
       dans l'un des évènenents de cette conférence.
+    no_people_in_event: |
+      Il n'y a pas de personne associée à cet évènement pour le moment.
+      Utilisez le bouton sur la droite pour en ajouter. Notez que vous
+      pouvez seulement ajouter des personnes qui sont déjà présentes dans le
+      système. Si vous voulez ajouter quelqu'un qui n'est pas encore dedans,
+      allez sur l'onglet _Personnes_ et créez cette personne en premier.
     no_user_account: |
       Cette personne n'a pas encore de compte utilisateur et ne peut donc pas se connecter.
       Cliquez sur l'onglet _Utilisateurs_ pour créer un compte.


### PR DESCRIPTION
This PR fixes a translation keyword used in people view.

According to similar translation keywords used in `people_module` (ie. `no_people_involved`, `no_people_data`), `no_people_in event` have a missing underscore character.

Plus, `no_people_in event` translations in EN and FR were placed at a different level in yaml tree.
It was `people_module.inputs.no_people_in event` where others are directly under `people_module` like `people_module.no_people_involved`.
  