### PR TITLE
Fix translation keywords in events view

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -3,7 +3,7 @@
     .pull-right
       - if policy(@conference).manage?
         = action_button "primary", t('events_module.edit_event'), edit_event_path(@event), hint: t('events_module.edit_event_hint')
-        = action_button "primary", t('people_module.edit_people'), edit_people_event_path(@event), hint: t('people_module.inputs.edit_people_hint')
+        = action_button "primary", t('events_module.edit_people'), edit_people_event_path(@event), hint: t('events_module.edit_people_hint')
         - if @conference.ticket_type == 'integrated' and !@conference.bulk_notification_enabled and @conference.call_for_participation.present?
           - if @event.transition_possible? :accept
             = action_button "success", t('events_module.accept_event'), update_state_event_path(@event, transition: :accept, send_mail: true), method: :put, hint: t('events_module.accept_event_hint')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -912,6 +912,8 @@ en:
     custom_notification_hint: Add custom notifications for all speakers. These will be sent instead of the default notification on next bulk notification run. Modify them in 'Edit people' tab.
     edit_event: Edit Event
     edit_event_hint: Edit this event's data.
+    edit_people: Edit people
+    edit_people_hint: Add or remove people from this event.
     error_no_day: |
       Before you can schedule any events, you need
       to have at least one day defined for this
@@ -1694,8 +1696,6 @@ en:
     edit_person: Edit person
     edit_person_hint: Edit this person's data.
     inputs:
-      edit_people: Edit people
-      edit_people_hint: Add or remove people from this event.
       hints:
         event_role: |
           Coordinators are part of the conference team, they coordinate speaker

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -967,6 +967,8 @@ fr:
       prochain enoi groupé. Modifiez-les dans l'onglet "Éditer des personnes"
     edit_event: Éditer l'évènement
     edit_event_hint: Éditer les données de cet évènement
+    edit_people: Éditer les personnes
+    edit_people_hint: Ajouter ou enlever des personnes à cet évènement.
     error_no_day: |
       Avant de pouvoir programmer des évènements, vous devez avoir au moins
       une journée de définie pour cette conférence. Allez dans les
@@ -1747,8 +1749,6 @@ fr:
     edit_person: Éditer la personne
     edit_person_hint: Éditer les données de la personne.
     inputs:
-      edit_people: Éditer les personnes
-      edit_people_hint: Ajouter ou enlever des personnes à cet évènement.
       hints:
         event_role: |
           Les coordinateurs font partie de l'équipe de la conférence. Ils coordinent le


### PR DESCRIPTION
This PR fixes two translation keywords in `events` view:
* In view code, `edit_people` and `edit_people_hint` were searched in `people_module` instead of `events_module`
* In EN and FR files, `edit_people` and `edit_people_hint` were placed under `inputs` instead of root of module (ie. `events_module.edit_people` and `events_module.edit_people_hint`