### PR TITLE
public booklet: add speakers

### DIFF
--- a/app/views/public/schedule/booklet.html.haml
+++ b/app/views/public/schedule/booklet.html.haml
@@ -30,3 +30,7 @@
             %p= event.abstract.truncate(250)
           - if event.description.present?
             %p= event.description.truncate(1200)
+          .speakers
+            %ul
+              - event.speakers.each do |speaker|
+                %li= link_to speaker.public_name, public_speaker_path(id: speaker.id)


### PR DESCRIPTION
On public booklet view, speakers was missing.
This PR adds speakers list on bottom of each event.