### PR TITLE
Show sub conferences

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -65,8 +65,8 @@ class Conference < ApplicationRecord
     joins(:conference_users).where(conference_users: { user_id: user, role: 'orga' })
   }
 
-  scope :past, -> { includes(:days).where(Day.arel_table[:end_date].lt(Time.now)).order('days.start_date DESC').distinct }
-  scope :future, -> { includes(:days).where(Day.arel_table[:end_date].gt(Time.now)).order('days.start_date DESC').distinct }
+  scope :past, -> { where(Conference.arel_table[:end_date].lt(Time.now)).order('start_date DESC') }
+  scope :future, -> { where(Conference.arel_table[:end_date].gt(Time.now)).order('start_date DESC') }
 
   self.per_page = 10
 

--- a/app/views/home/_table.html.haml
+++ b/app/views/home/_table.html.haml
@@ -11,9 +11,9 @@
           - if conference.logo.present?
             = image_box conference&.logo, :small
         %td
-          = l(conference.days.first.start_date.to_date)
+          = l(conference.start_date.to_date)
           \-
-          = l(conference.days.last.end_date.to_date)
+          = l(conference.end_date.to_date)
         %td= conference.title
         %td
           - if show_cfp?(current_user, conference)

--- a/db/migrate/20180213195422_add_dates_to_conferences.rb
+++ b/db/migrate/20180213195422_add_dates_to_conferences.rb
@@ -1,0 +1,6 @@
+class AddDatesToConferences < ActiveRecord::Migration[5.1]
+  def change
+    add_column :conferences, :start_date, :datetime
+    add_column :conferences, :end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110140104) do
+ActiveRecord::Schema.define(version: 20180213195422) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer "person_id"
@@ -97,6 +97,8 @@ ActiveRecord::Schema.define(version: 20171110140104) do
     t.integer "logo_file_size"
     t.datetime "logo_updated_at"
     t.boolean "schedule_open", default: false, null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["acronym"], name: "index_conferences_on_acronym"
     t.index ["parent_id"], name: "index_conferences_on_parent_id"
   end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -14,6 +14,7 @@ class HomeControllerTest < ActionController::TestCase
     assert_response :success
     assert_includes response.body, '>present conference'
     assert_includes response.body, '>future conference'
+    assert_includes response.body, '>future conference sub'
     refute_includes response.body, '>past conference'
     refute_includes response.body, '>other conference'
   end

--- a/test/models/conference_test.rb
+++ b/test/models/conference_test.rb
@@ -79,7 +79,7 @@ class ConferenceTest < ActiveSupport::TestCase
     create(:future_call_for_participation, conference: future)
     future = create(:three_day_conference, title: 'future conference')
     create(:future_call_for_participation, conference: future)
-    assert_equal 2, Conference.future.count
+    assert_equal 4, Conference.future.count
   end
 
   test 'inherits from parent conference' do

--- a/test/models/day_test.rb
+++ b/test/models/day_test.rb
@@ -24,4 +24,13 @@ class DayTest < ActiveSupport::TestCase
     conference.days[1].start_date = conference.days[0].end_date.ago(2.hours)
     assert_equal false, conference.days[1].valid?
   end
+
+  test 'updating day updates conference' do
+    conference = create(:three_day_conference)
+    conference.reload
+    assert conference.start_date
+    assert conference.end_date
+    assert conference.subs.last.start_date
+    assert conference.subs.last.end_date
+  end
 end

--- a/test/support/capybara_helper.rb
+++ b/test/support/capybara_helper.rb
@@ -11,9 +11,9 @@ module CapybaraHelper
     sign_in(user.email, 'frab123')
   end
 
-  def visit_conference_settings
+  def visit_conference_settings(matcher = :first)
     click_on 'Conferences'
-    click_on 'Show'
+    click_on 'Show', match: matcher
     find('ul.nav:eq(2)').click_link('Settings')
   end
 end


### PR DESCRIPTION
No longer rely on the join with days to find out the start and end of a conference. Cache the values on conference model instead.

Listing sub conferences via future/past should work now, fixing https://github.com/frab/frab/issues/409