### PR TITLE
Fix missing translation in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,7 +263,7 @@ en:
     login: Log-in
     login_existing_description: You can sign in if you created an account for this Call for Participation, or for any previous event.
     login_existing_headline: Log in with an existing account
-    looking_for_login_form: Suchen Sie den Login für Vortragende?
+    looking_for_login_form: Are you looking for the login of submitters?
     no_confirmation_token: Your confirmation key is not valid. Please check your event status in the call for papers interface.
     not_forget_personal_details: And do not forget to fill out your personal details if you have not done so already. Please remember that you can always go back and edit your profile using the button in the right sidebar.
     notifications:


### PR DESCRIPTION
'Suchen Sie den Login für Vortragende?'
  → 'Are you looking for the login of submitters?'