### PR TITLE
Need duration for our track team when planning 35C3

### DIFF
--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -3,6 +3,7 @@ json.guid event.guid
 json.title event.title
 json.subtitle event.subtitle
 json.description event.description
+json.duration event.duration_in_minutes
 json.logo event.logo_path(:original)
 json.type event.event_type
 json.do_not_record event.do_not_record


### PR DESCRIPTION
Add duration value to event exports, so that our track teams can better plan with their companion tool.