### PR TITLE
Remove SMTP_NOTLS ENV Var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ ENV RACK_ENV=production \
     FROM_EMAIL=frab@localhost \
     SMTP_ADDRESS=172.17.0.1 \
     SMTP_PORT=25 \
-    SMTP_NOTLS=true \
     DATABASE_URL=sqlite3://localhost/home/frab/data/database.db
 
 CMD ["/home/frab/app/docker-cmd.sh"]


### PR DESCRIPTION
Remove the SMTP_TLS Enironment variable to restore the ability to use Mailservers with TLS enabled.
As described here ( https://github.com/frab/frab/issues/446#issuecomment-446471008 ) the existance of this Var disables TLS Support completely..
This change adds the ability to use TLS-Mail back into the Docker Image