### PR TITLE
Re-add ActiveRecord schema migrations in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,8 @@ contrib/
 tmp/
 log/
 db/
+!db/schema.rb
+!db/seeds.rb
+!db/migrate/
 public/system
 


### PR DESCRIPTION
Removing the complete `db/` folder makes the final Docker image
unusable, since it cannot initialize or upgrade the database. This
commit adds exceptions, so that the ActiveRecord migration files are
included, while still keeping random SQLite files excluded.