### PR TITLE
Change 'enabled' string logic

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -28,14 +28,14 @@ de:
         name: Name
       conference:
         acronym: Kürzel
-        bulk_notification_enabled: Massen-Mailings aktiviert
+        bulk_notification_enabled: Massen-Mailings
         color: Farbe
         default_recording_license: Standard-Aufnahmelizenz
         default_timeslots: Standard-Anzahl Zeitslots
         email: E-Mail
         event_state_visible: Eventstatus für Einreichende sichtbar
-        expenses_enabled: Spesen aktiviert
-        feedback_enabled: Feedback aktiviert
+        expenses_enabled: Spesenverfolgung
+        feedback_enabled: Feedback
         max_timeslots: Maximale Anzahl Zeitslots
         program_export_base_url: URL des Programm-Exports
         schedule_custom_css: Benutzerdefiniertes CSS im Programm-Export
@@ -47,7 +47,7 @@ de:
         timeslot_duration: Dauer eines Zeitslots
         timezone: Zeitzone
         title: Titel
-        transport_needs_enabled: Transportbedarf aktiviert
+        transport_needs_enabled: Transportbedarfsnachverfolgung
       conference_export:
         locale: Gebietsschema
       conference_user:
@@ -486,7 +486,7 @@ de:
           Der Name der Konferenz, wie sie auf der gesamten Website erscheinen soll.
           Beispiel: 'FrOSCon'
         transport_needs_enabled: |
-          Wenn aktiviert, können Sie mit frab den Transportbedarf der Sprecher verwalten
+          Wenn aktiviert, können Sie mit frab den Transportbedarf der Sprecher verwalten.
     manage_conferences: Konferenzen verwalten
     manage_conferences_hint: Verwalten Sie alle Konferenzen
     new: Neu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,14 +21,14 @@ en:
         name: Name
       conference:
         acronym: Acronym
-        bulk_notification_enabled: Bulk notifications enabled
+        bulk_notification_enabled: Bulk notifications
         color: Color
         default_recording_license: Default recording license
         default_timeslots: default timeslots
         email: E-Mail
         event_state_visible: Event state visible
-        expenses enabled: Expenses enabled
-        feedback_enabled: Feedback enabled
+        expenses_enabled: Expense tracking
+        feedback_enabled: Feedback
         max_timeslots: Max. timeslots
         program_export_base_url: Program export URL
         schedule_custom_css: Schedule custom CSS
@@ -40,7 +40,7 @@ en:
         timeslot_duration: Timeslot duration
         timezone: Timezone
         title: title
-        transport_needs_enabled: Transport needs enabled
+        transport_needs_enabled: Transport needs tracking
       conference_export:
         locale: Locale
       conference_user:
@@ -433,7 +433,7 @@ en:
           If you enable this, speakers will be able to look up the state
           of their submission in the cfp interface and confirm their attendance
           by pressing the confirm button.
-        expenses_enabled: If you enable this, frab will allow you to track expenses of people
+        expenses_enabled: If you enable this, frab will allow you to track expenses of people.
         feedback_enabled: |
           If you enable this, your program export will include links to a feedback
           form where attendees can rate an event.
@@ -458,7 +458,7 @@ en:
           Example: 'FrOSCon'
         transport_needs_enabled: |
           If you enable this, frab will allow you to track transportation needs of
-          people
+          people.
     manage_conferences: Manage conferences
     manage_conferences_hint: Manage all conferences
     new: New

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -28,14 +28,14 @@ es:
         name: Nombre
       conference:
         acronym: Abreviación
-        bulk_notification_enabled: Notificaciones masivas habilitadas
+        bulk_notification_enabled: Notificaciones masivas
         color: Color
         default_recording_license: Licencia de grabación predeterminada
         default_timeslots: Intervalos por defecto
         email: E-Mail
         event_state_visible: Estado del evento visible
-        expenses enabled: Gastos habilitados
-        feedback_enabled: Retroalimentación habilitada
+        expenses_enabled: Gastos
+        feedback_enabled: Retroalimentación
         max_timeslots: Máximo de intervalos
         program_export_base_url: URL de exportación del programa
         schedule_custom_css: Programar CSS personalizado
@@ -47,7 +47,7 @@ es:
         timeslot_duration: Duración de intervalo
         timezone: Huso horario
         title: Título
-        transport_needs_enabled: Necesidades de transporte habilitadas
+        transport_needs_enabled: Necesidades de transporte
       conference_export:
         locale: Lugar
       conference_user:
@@ -476,7 +476,7 @@ es:
           Si habilita esto, los oradores podrán buscar el estado
           de su presentación en la interfaz de cfp y confirmar su asistencia
           presionando el botón confirmar.
-        expenses_enabled: Si habilita esto, frab le permitirá rastrear los gastos de las personas
+        expenses_enabled: Si habilita esto, frab le permitirá rastrear los gastos de las personas.
         feedback_enabled: |
           Si habilita esto, la exportación de su programa incluirá enlaces a comentarios
           formulario donde los asistentes pueden calificar un evento.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,8 +27,8 @@ fr:
         default_timeslots: Plage horaire par défaut
         email: Courriel
         event_state_visible: Statut visible des évènements
-        expenses enabled: Dépenses activées
-        feedback_enabled: Retours activés
+        expenses_enabled: Dépenses
+        feedback_enabled: Retours
         max_timeslots: Nombre de plages max.
         program_export_base_url: URL d’export du programme
         schedule_custom_css: CSS personalisé pour le programme
@@ -40,7 +40,7 @@ fr:
         timeslot_duration: Plage horaire
         timezone: Fuseau horaire
         title: Titre
-        transport_needs_enabled: Besoin de transport activé
+        transport_needs_enabled: Besoin de transport
       conference_export:
         locale: Langue
       conference_user:
@@ -436,7 +436,7 @@ fr:
           et confirmer leur présence en cliquant sur le bouton associé.
         expenses_enabled: |
           Si vous activez cette option, frab vous permettra de suivre les dépenses
-          des personnes
+          des personnes.
         feedback_enabled: |
           Si vous activez cette option, l’export de votre programme incluera des liens
           permettant aux visiteurs donner leur appréciation sur les évènements.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -27,8 +27,8 @@ it:
         default_timeslots: Intervallo di tempo predefinito
         email: e-mail
         event_state_visible: Stato visibile degli eventi
-        expenses enabled: Spese attivate
-        feedback_enabled: Restituzioni abilitate
+        expenses_enabled: Spese attivate
+        feedback_enabled: Restituzioni
         max_timeslots: Numero di tracce max.
         program_export_base_url: Programma l'URL di esportazione
         schedule_custom_css: CSS personalizzato per il programma
@@ -40,7 +40,7 @@ it:
         timeslot_duration: Intervallo di tempo
         timezone: fuso orario
         title: titolo
-        transport_needs_enabled: Hai bisogno di trasporto abilitato
+        transport_needs_enabled: Hai bisogno di trasporto
       conference_export:
         locale: Lingua
       conference_user:
@@ -436,7 +436,7 @@ it:
           e confermare la loro presenza facendo clic sul pulsante associato.
         expenses_enabled: |
           Se abiliti questa opzione, frab ti permetterà di tenere traccia delle spese
-          persone
+          persone.
         feedback_enabled: |
           Se abiliti questa opzione, l'esportazione del tuo programma includerà i collegamenti
           permettendo ai visitatori di dare il loro apprezzamento degli eventi.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -28,14 +28,14 @@ pt-BR:
         name: Nome
       conference:
         acronym: Acrônimo
-        bulk_notification_enabled: Notificações em massa ativadas
+        bulk_notification_enabled: Notificações em massa
         color: Cor
         default_recording_license: Licença de gravação padrão
         default_timeslots: Duração Padrão dos Slots
         email: E-Mail
         event_state_visible: Estado do evento visível
-        expenses enabled: Despesas habilitadas
-        feedback_enabled: Comentários habilitados
+        expenses_enabled: Despesas
+        feedback_enabled: Comentários
         max_timeslots: Duração Máxima dos Slots
         program_export_base_url: URL de exportação do programa
         schedule_custom_css: Agendar CSS personalizado
@@ -47,7 +47,7 @@ pt-BR:
         timeslot_duration: Duração dos Slots
         timezone: Fuso Horário
         title: Título
-        transport_needs_enabled: Necessidades de transporte ativadas
+        transport_needs_enabled: Necessidades de transporte
       conference_export:
         locale: Localidade
       conference_user:
@@ -453,7 +453,7 @@ pt-BR:
           Se você ativar isso, os falantes poderão procurar o estado
           de sua apresentação na interface cfp e confirmar sua presença
           pressionando o botão confirmar.
-        expenses_enabled: Se você ativar isso, frab permitirá que você controle as despesas de pessoas
+        expenses_enabled: Se você ativar isso, frab permitirá que você controle as despesas de pessoas.
         feedback_enabled: |
           Se você habilitar isso, a exportação do seu programa incluirá links para um feedback
           formulário onde os participantes podem avaliar um evento.
@@ -478,7 +478,7 @@ pt-BR:
           Exemplo: 'FrOSCon'
         transport_needs_enabled: |
           Se você ativar isso, o frab permitirá que você rastreie as necessidades de transporte de
-          pessoas
+          pessoas.
     manage_conferences: Gerenciar conferências
     manage_conferences_hint: Gerenciar todas as conferências
     new: Novo

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -27,7 +27,7 @@ ru:
         default_timeslots: временные интервалы по умолчанию
         email: Эл. почта
         event_state_visible: Состояние события видимо
-        expenses enabled: Расходы включены
+        expenses_enabled: Расходы включены
         feedback_enabled: Обратная связь включена
         max_timeslots: Максимум. временные интервалы
         program_export_base_url: URL-адрес экспорта программы

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -27,7 +27,7 @@ zh:
         default_timeslots: 默认时隙
         email: 电子邮件
         event_state_visible: 事件状态可见
-        expenses enabled: 支出已启用
+        expenses_enabled: 支出已启用
         feedback_enabled: 已启用反馈
         max_timeslots: 最大。时隙
         program_export_base_url: 节目导出网址


### PR DESCRIPTION
The descriptive strings are currently only used in a view for the
conference settings, under the heading 'additional features' with
checkboxes beside them.

From a logical point of view, writing "enabled" and having a checkbox is
fairly redundant (if a checkbox is checked, something is active, after
all); thus I propose removing the "enabled" bit of the string and have
done this in all the languages whose characters I can decipher and know
if the grammar would be impacted by a change. (Spoilers: it isn't for
romance or germanic languages)

Additionally, some of the strings were incorrectly referenced as
'expenses enabled', without the underscore, which I've supplied.