### PR TITLE
Fix variable reference in thank you template

### DIFF
--- a/app/views/public/feedback/thank_you.html.haml
+++ b/app/views/public/feedback/thank_you.html.haml
@@ -8,6 +8,6 @@
 
   %p
     - if @conference.program_export_base_url.present?
-      = link_to t('.return'), public_program_event_url(event)
+      = link_to t('.return'), public_program_event_url(@event)
     - else
       = link_to t('.return'), public_schedule_path(day: @conference.day_at(@event.start_time))


### PR DESCRIPTION
The wrong variable would read to a not very nice UX when giving a
rating, as it would fail.