### PR TITLE
Make max attachment size configurable

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -185,9 +185,9 @@ class ConferencesController < BaseConferenceController
   def allowed_params
     [
       :acronym, :bulk_notification_enabled, :color, :default_recording_license, :default_timeslots, :email,
-      :event_state_visible, :expenses_enabled, :feedback_enabled, :max_timeslots, :program_export_base_url,
-      :schedule_custom_css, :schedule_html_intro, :schedule_public, :schedule_open, :schedule_version, :ticket_type,
-      :title, :transport_needs_enabled,
+      :event_state_visible, :expenses_enabled, :feedback_enabled, :max_timeslots, :max_attachment_size_mb,
+      :program_export_base_url, :schedule_custom_css, :schedule_html_intro, :schedule_public, :schedule_open,
+      :schedule_version, :ticket_type, :title, :transport_needs_enabled,
       languages_attributes: %i(language_id code _destroy id),
       ticket_server_attributes: %i(url user password queue _destroy id),
       notifications_attributes: %i(id locale accept_subject accept_body reject_subject reject_body schedule_subject schedule_body _destroy)

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -30,6 +30,7 @@ class Conference < ApplicationRecord
     :acronym,
     :default_timeslots,
     :max_timeslots,
+    :max_attachment_size_mb,
     :timeslot_duration,
     :timezone, presence: true
   validates :feedback_enabled,

--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -3,7 +3,10 @@ class EventAttachment < ApplicationRecord
 
   has_attached_file :attachment
 
-  validates_attachment_size :attachment, less_than: 42.megabytes
+  validates_attachment_presence :attachment
+
+  validate :filesize_ok
+
   do_not_validate_attachment_file_type :attachment
 
   has_paper_trail meta: { associated_id: :event_id, associated_type: 'Event' }
@@ -17,6 +20,15 @@ class EventAttachment < ApplicationRecord
       attachment_file_name
     else
       I18n.t('activerecord.models.event_attachment')
+    end
+  end
+  
+  def filesize_ok
+    if not attachment_file_size.nil?
+      if attachment_file_size > event.conference.max_attachment_size_mb.megabytes
+        errors.add(:attachment, I18n.t('events_module.error_attachment_too_large',
+          allowed_mb: event.conference.max_attachment_size_mb))
+      end
     end
   end
 end

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -29,6 +29,7 @@
     %legend= t(:submission_configuration)
     = f.input :event_state_visible, as: :inline_boolean, hint: t('conferences_module.inputs.hints.event_state_visible')
     = f.input :default_recording_license, hint: t('conferences_module.inputs.hints.default_recording_license')
+    = f.input :max_attachment_size_mb, hint: t('conferences_module.inputs.hints.max_attachment_size_mb')
   %fieldset.inputs
     %legend= t(:features)
     = f.input :feedback_enabled, as: :inline_boolean, hint: t('conferences_module.inputs.hints.feedback_enabled')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
         event_state_visible: Event state visible
         expenses_enabled: Expense tracking
         feedback_enabled: Feedback
+        max_attachment_size_mb: Max attachment size
         max_timeslots: Max. timeslots
         program_export_base_url: Program export URL
         schedule_custom_css: Schedule custom CSS
@@ -437,6 +438,7 @@ en:
         feedback_enabled: |
           If you enable this, your program export will include links to a feedback
           form where attendees can rate an event.
+        max_attachment_size_mb: Specify the maximum accepted file size of an attachment (in MB)  
         max_timeslots: What is the maximum length of a single event (e.g. a single talk)?
         timeslot_duration: |
           How long do you want the smallest timeslots to be? This essentially
@@ -951,6 +953,7 @@ en:
       to have at least one room defined for this
       conference. Go to _Settings_
       above to enter a room.
+    error_attachment_too_large: 'too large. Max allowed size is %{allowed_mb} MB.'  
     event_attachments: Uploaded files
     event_classifiers: Event classifiers
     event_details: Event details

--- a/db/migrate/20190811101826_add_max_attachment_size_mb_to_conferences.rb
+++ b/db/migrate/20190811101826_add_max_attachment_size_mb_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddMaxAttachmentSizeMbToConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column :conferences, :max_attachment_size_mb, :integer, default: 42
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_30_033823) do
+ActiveRecord::Schema.define(version: 2019_08_11_101826) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer "person_id"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2018_12_30_033823) do
     t.boolean "schedule_open", default: false, null: false
     t.datetime "start_date"
     t.datetime "end_date"
+    t.integer "max_attachment_size_mb", default: 42
     t.index ["acronym"], name: "index_conferences_on_acronym"
     t.index ["parent_id"], name: "index_conferences_on_parent_id"
   end


### PR DESCRIPTION
Max attachment size is now configurable per conference. 

Closes #493