### PR TITLE
DISABLE_FRAB_DIRECT_LOGIN broke change user role

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,7 +52,9 @@ class UsersController < BaseCrewController
 
     respond_to do |format|
       if @user.update_attributes(user_params)
-        @user.confirm unless @user.confirmed?
+        if @user.respond_to?(:confirm)
+          @user.confirm unless @user.confirmed?
+        end
         bypass_sign_in(@user) if current_user == @user
         format.html { redirect_to(edit_crew_user_path(@person), notice: t('users_module.notice_user_updated')) }
       else


### PR DESCRIPTION
When DISABLE_FRAB_DIRECT_LOGIN=1 then user is not confirmable so @user.confirm would fail. This function is called during "change role" from web gui.