### PR TITLE
preset attachment titles

### DIFF
--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -184,7 +184,7 @@ class ConferencesController < BaseConferenceController
 
   def allowed_params
     [
-      :acronym, :bulk_notification_enabled, :color, :default_recording_license, :default_timeslots, :email,
+      :acronym, :attachment_title_is_freeform, :bulk_notification_enabled, :color, :default_recording_license, :default_timeslots, :email,
       :event_state_visible, :expenses_enabled, :feedback_enabled, :max_timeslots, :program_export_base_url,
       :schedule_custom_css, :schedule_html_intro, :schedule_public, :schedule_open, :schedule_version, :ticket_type,
       :title, :transport_needs_enabled,

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -32,7 +32,8 @@ class Conference < ApplicationRecord
     :max_timeslots,
     :timeslot_duration,
     :timezone, presence: true
-  validates :feedback_enabled,
+  validates :attachment_title_is_freeform,
+    :feedback_enabled,
     :expenses_enabled,
     :transport_needs_enabled,
     :bulk_notification_enabled, inclusion: { in: [true, false] }

--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -1,4 +1,5 @@
 class EventAttachment < ApplicationRecord
+  ATTACHMENT_TITLES = %w(proposal poster slides handouts media video other).freeze
   belongs_to :event
 
   has_attached_file :attachment
@@ -9,10 +10,10 @@ class EventAttachment < ApplicationRecord
   has_paper_trail meta: { associated_id: :event_id, associated_type: 'Event' }
 
   scope :is_public, -> { where(public: true) }
-
+  
   def link_title
     if title.present?
-      title
+      I18n.t(title, default: title, scope: 'events_module.predefined_title_types')
     elsif attachment_file_name.present?
       attachment_file_name
     else

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -28,6 +28,7 @@
   %fieldset.inputs
     %legend= t(:submission_configuration)
     = f.input :event_state_visible, as: :inline_boolean, hint: t('conferences_module.inputs.hints.event_state_visible')
+    = f.input :attachment_title_is_freeform, as: :inline_boolean, hint: t('conferences_module.inputs.hints.attachment_title_is_freeform')
     = f.input :default_recording_license, hint: t('conferences_module.inputs.hints.default_recording_license')
   %fieldset.inputs
     %legend= t(:features)

--- a/app/views/shared/_event_attachment_fields.html.haml
+++ b/app/views/shared/_event_attachment_fields.html.haml
@@ -1,12 +1,16 @@
 .nested-fields
   %fieldset.inputs
+    - if @conference.attachment_title_is_freeform
+      = f.input :title, as: :string
+    - else
+      = f.input :title, 
+                as: :select, 
+                collection: EventAttachment::ATTACHMENT_TITLES.map{|s| [t(s, scope: 'events_module.predefined_title_types'), s]}.to_h
+      
+    = f.input :public, as: :inline_boolean, hint: t('events_module.public_attachment_hint')
     - if f.object.new_record?
-      = f.input :title
-      = f.input :public, as: :inline_boolean, hint: t('events_module.public_attachment_hint')
       = f.input :attachment
     - else
-      = f.input :title
-      = f.input :public, as: :inline_boolean, hint: t('events_module.public_attachment_hint')
       .input
         = link_to f.object.attachment_file_name, f.object.attachment.url, style: 'float:left'
     = remove_association_link :event_attachment, f

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,6 +416,10 @@ en:
           A short and unique handle for your conference, using only lower-case
           letters, numbers and underscores. This will be used to identify your
           conference in URLs etc. Example: 'froscon2011'
+        attachment_title_is_freeform: |
+          If this option is selected, submitters can provide any title they want
+          for files they upload as attachments. If this option is deselected, they
+          must select between a set of pre-configured titles.
         bulk_notification_enabled: |
           If you enable this, notifications will be sent out in bulk by mail
           or ticket subsystem.
@@ -928,6 +932,14 @@ en:
     add_ticket_hint: Create a ticket for this event.
     all_events: All events
     all_rating: All ratings
+    predefined_title_types:
+      handouts: handouts
+      media: media
+      other: other
+      poster: poster
+      proposal: proposal
+      slides: slides
+      video: video
     average_feedback: 'Average Feedback:'
     average_speaker_feedback: 'Average feedback as speaker:'
     cancel_event: Cancel event

--- a/db/migrate/20190829134733_add_free_form_attachment_title_to_conferences.rb
+++ b/db/migrate/20190829134733_add_free_form_attachment_title_to_conferences.rb
@@ -1,0 +1,5 @@
+class AddFreeFormAttachmentTitleToConferences < ActiveRecord::Migration[5.2]
+  def change
+    add_column :conferences, :attachment_title_is_freeform, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_11_121538) do
+ActiveRecord::Schema.define(version: 2019_08_29_134733) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer "person_id"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_08_11_121538) do
     t.boolean "schedule_open", default: false, null: false
     t.datetime "start_date"
     t.datetime "end_date"
+    t.boolean "attachment_title_is_freeform", default: true
     t.index ["acronym"], name: "index_conferences_on_acronym"
     t.index ["parent_id"], name: "index_conferences_on_parent_id"
   end


### PR DESCRIPTION
conference admin can now select between two ways for submitters to
describe the file attachment they upload,

1. freeform title - which is the default - maintains existing behavior:
submitters can type in any title they want.

2. non free-form. Only a set of titles are allowed:
proposal slides poster video other
This list is subjet to i18n


See https://github.com/frab/frab/issues/492