### PR TITLE
add papertrail for classifiers

### DIFF
--- a/app/models/classifier.rb
+++ b/app/models/classifier.rb
@@ -1,5 +1,11 @@
 class Classifier < ApplicationRecord
   belongs_to :conference
   has_many :event_classifiers, dependent: :destroy
+  
+  has_paper_trail meta: { associated_id: :conference_id, associated_type: 'Conference' }
 
+  def to_s
+    "#{model_name.human}: #{name}"
+  end
+  
 end


### PR DESCRIPTION
this way, changing a conference's classifiers list is shown in "recent
changes" list.

This PR does not deal with logging a change to the classifier value for a specific event.