### PR TITLE
fix papertrail for event attachments

### DIFF
--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -19,4 +19,8 @@ class EventAttachment < ApplicationRecord
       I18n.t('activerecord.models.event_attachment')
     end
   end
+
+   def to_s
+     "#{model_name.human}: #{link_title}"
+   end
 end


### PR DESCRIPTION
in the recent changes view, attachment changes will now
show as "file: title" instead of "#".

 
![image](https://user-images.githubusercontent.com/20379005/64317197-9bbbf380-cfbf-11e9-8a94-3125cbcebed3.png)
