### PR TITLE
regenerate invite token on import if needed

### DIFF
--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -134,6 +134,7 @@ class ImportExportHelper
       if (file = import_file('events/logos', id, obj.logo_file_name))
         obj.logo = file
       end
+      obj.regenerate_invite_token if Event.where(invite_token: obj.invite_token).any?
       obj.save!
       @mappings[:events][id] = obj.id
     end


### PR DESCRIPTION
Prior to this change, it was not possible to import the same conference
twice simply by changing its conference acronym, because the invite
token would have been duplicate.