### PR TITLE
import omniauth data

### DIFF
--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -117,6 +117,7 @@ class ImportExportHelper
             current_sign_in_at current_sign_in_ip last_sign_in_at
             last_sign_in_ip encrypted_password
             remember_created_at remember_token
+            provider uid
             reset_password_token role sign_in_count updated_at).each { |var|
           obj.send("#{var}=", yaml[var])
         }


### PR DESCRIPTION
when exporting using frab:conference_export, the omniauth data (used to
enable logging in with 3rd party authenticators) is exported. With this
commit, then this data is also used when importing with
frab:conference_import); so a user which was able to log in to the
original frab with her Google account will now be able to log in to the
new frab as well.

Existing users on the destination frab are not modified.

This is a completion of https://github.com/frab/frab/issues/499