### PR TITLE
add "Attachment overview" screen

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,6 +54,22 @@ class EventsController < BaseConferenceController
       format.pdf
     end
   end
+  
+  # show a table of all events' attachments
+  def attachments
+    authorize @conference, :read?
+    
+    result = search @conference.events
+    @events = result.paginate page: page_param
+    clean_events_attributes
+    
+    attachments = EventAttachment.joins(:event).where('events.conference': @conference)
+    preset_attachment_titles_in_use = attachments.where(title: EventAttachment::ATTACHMENT_TITLES).group(:title).pluck(:title)
+    
+    @attachment_titles = EventAttachment::ATTACHMENT_TITLES & preset_attachment_titles_in_use
+    
+    @other_attachment_titles_exist = attachments.where.not(title: EventAttachment::ATTACHMENT_TITLES).any?
+  end
 
   # show event ratings
   def ratings

--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -1,5 +1,7 @@
 class EventAttachment < ApplicationRecord
   ATTACHMENT_TITLES = %w(proposal poster slides handouts media video other).freeze
+  include ActionView::Helpers::DateHelper
+  
   belongs_to :event
 
   has_attached_file :attachment
@@ -21,7 +23,17 @@ class EventAttachment < ApplicationRecord
     end
   end
 
-   def to_s
-     "#{model_name.human}: #{link_title}"
-   end
+  def to_s
+    "#{model_name.human}: #{link_title}"
+  end
+
+  def short_anonymous_title
+    dt = attachment_updated_at.to_datetime
+    if dt.year==Date.today.year
+      s = I18n.t(:ago, time_ago: time_ago_in_words(dt), scope: 'events_module')
+    else
+      s = dt.year.to_s
+    end
+    "\u{1F5CE} " + s
+  end
 end

--- a/app/views/events/attachments.html.haml
+++ b/app/views/events/attachments.html.haml
@@ -1,37 +1,26 @@
 %section
   .page-header
     .pull-right
-      = action_button "primary", t('ratings_module.start_reviewing'), start_review_events_path, hint: t('ratings_module.start_reviewing_hint'), disabled: @events_no_review == 0
-    %h1= t('titles.event_ratings')
+    %h1= t('titles.attachments_overview')
   %ul.tabs
     %li= link_to t('events_module.all_events'), events_path
     %li= link_to t('events_module.my_events'), my_events_path
-    %li= link_to t('events_module.attachments_overview'), attachments_events_path
-    %li.active= link_to t('events_module.event_ratings'), ratings_events_path
+    %li.active= link_to t('events_module.attachments_overview'), attachments_events_path
+    %li= link_to t('events_module.event_ratings'), ratings_events_path
     - if @conference.feedback_enabled
       %li= link_to t('events_module.event_feedbacks'), feedbacks_events_path
   - if @events.all.empty?
     .row
       .span16
         .blank-slate
-          %p= t('ratings_module.no_event')
-  - else
-    = render partial: 'filters', locals: { params: params }
+          %p= t('attachments_overview_module.no_event')
+  - elsif @attachment_titles.empty? and not @other_attachment_titles_exist
     .row
       .span16
-        %h2= t('ratings_module.statistics')
-        %p
-          %b= t('ratings_module.total_number_of_events')
-          = @events_total
-          %br/
-          %b= t('ratings_module.total_number_of_events_no_review')
-          = @events_no_review_total
-          %br/
-          %b= t('ratings_module.total_number_of_reviewed')
-          = @events_reviewed
-          %br/
-          %b= t('ratings_module.total_number_of_not_reviewed')
-          = @events_no_review
+        .blank-slate
+          %p= t('attachments_overview_module.no_attachments')
+  - else
+    = render partial: 'filters', locals: { params: params }
     .row
       .span16
         %table.zebra-striped
@@ -43,9 +32,10 @@
               %th= sort_link @search, :event_type, term: params[:term]
               - if policy(@conference).manage?
                 %th= sort_link @search, :state, term: params[:term]
-              %th= sort_link @search, :average_rating, term: params[:term]
-              %th= sort_link @search, :event_ratings_count, term: params[:term]
-              %th
+              - @attachment_titles.each do |attachment_title|
+                %th= t(attachment_title, scope: 'events_module.predefined_title_types')
+              - if @other_attachment_titles_exist
+                %th= t('attachments_overview_module.attachments')
           %tbody
             - @events.includes(:track).each do |event|
               %tr
@@ -58,11 +48,9 @@
                 %td= link_to_unless params[:event_type].present?, event.event_type, request.query_parameters.merge(:event_type => event.event_type)
                 - if policy(@conference).manage?
                   %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
-                %td
-                  - if event.average_rating
-                    = raty_for("event_rating_#{event.id}", event.average_rating)
-                %td= event.event_ratings_count
-                %td
-                  = link_to t('ratings_module.show_ratings'), event_event_rating_path(event), class: "btn small"
+                - @attachment_titles.each do |attachment_title|
+                  %td= safe_join( event.event_attachments.where(title: attachment_title).map{|ea| link_to ea.short_anonymous_title, ea.attachment.url}, '<br>'.html_safe )
+                - if @other_attachment_titles_exist
+                  %td= safe_join( event.event_attachments.where.not(title: @attachment_titles).map{|ea| link_to ea.link_title, ea.attachment.url}, '<br>'.html_safe )
         = actions_bar do
           = will_paginate @events

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -10,6 +10,7 @@
   %ul.tabs
     %li.active= link_to t('events_module.all_events'), events_path
     %li= link_to t('events_module.my_events'), my_events_path
+    %li= link_to t('events_module.attachments_overview'), attachments_events_path
     %li= link_to t('events_module.event_ratings'), ratings_events_path
     - if @conference.feedback_enabled
       %li= link_to t('events_module.event_feedbacks'), feedbacks_events_path

--- a/app/views/events/my.html.haml
+++ b/app/views/events/my.html.haml
@@ -4,6 +4,7 @@
   %ul.tabs
     %li= link_to t('events_module.all_events'), events_path
     %li.active= link_to t('events_module.my_events'), my_events_path
+    %li= link_to t('events_module.attachments_overview'), attachments_events_path
     %li= link_to t('events_module.event_ratings'), ratings_events_path
     - if @conference.feedback_enabled
       %li= link_to t('events_module.event_feedbacks'), feedbacks_events_path

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -212,6 +212,13 @@ de:
     update_successful: Änderungen erfolgreich gespeichert!
   all: Alle
   are_you_sure: Sind Sie sicher?
+  attachments_overview_module:
+    attachments: Anhänge
+    no_attachments: |
+      Es sind noch keine Dateien an ein Ereignis angehängt. Einmal Menschen
+      Starten Sie das Hochladen von Dateien zu ihren Veranstaltungen
+      Alle Anhänge in diesem Bildschirm anzeigen.
+    no_event: Es gibt noch keine Veranstaltungen in dieser Konferenz. Sobald Ereignisse mit Dateianhängen hinzugefügt wurden, werden sie hier angezeigt.
   availabilities:
     alerts:
       available_for_day: verfügbar am Tag %{day}
@@ -929,8 +936,10 @@ de:
     add_event_hint: Fügen Sie ein neues Event hinzu.
     add_ticket: Ticket hinzufügen
     add_ticket_hint: Erstellen Sie ein Ticket für dieses Ereignis.
+    ago: vor %{time_ago}
     all_events: Alle Events
     all_rating: Alle Bewertungen
+    attachments_overview: Anhänge
     average_feedback: 'Durchschnittliches Feedback:'
     average_speaker_feedback: 'Durchschnittliches Feedback als Sprecher:'
     cancel_event: Event absagen
@@ -2038,6 +2047,7 @@ de:
   title: Titel
   titles:
     admin_accounts: Liste der Konten mit Administrator-Rechten
+    attachments_overview: Übersicht über Anhänge
     cfp_edit_cfp: Bearbeiten Sie den Call for Participation
     cfp_new_cfp: Starten Sie einen Call for Participation
     cfp_view: Call for Participation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,13 @@ en:
     update_successful: Changes saved successfully!
   all: All
   are_you_sure: Are you sure?
+  attachments_overview_module:
+    no_event: There are no events in this conference yet. Once events with file attachments are added, they will appear here.
+    no_attachments: |
+      There are no files attached to any of the events yet. Once people
+      start uploading files to their events, you will be able to
+      see all of the attachments in this screen.
+    attachments: attachments  
   availabilities:
     alerts:
       available_for_day: available for day %{day}
@@ -930,6 +937,7 @@ en:
     add_event_hint: Add a new event.
     add_ticket: Add Ticket
     add_ticket_hint: Create a ticket for this event.
+    ago: "%{time_ago} ago"
     all_events: All events
     all_rating: All ratings
     predefined_title_types:
@@ -940,6 +948,7 @@ en:
       proposal: proposal
       slides: slides
       video: video
+    attachments_overview: Attachments
     average_feedback: 'Average Feedback:'
     average_speaker_feedback: 'Average feedback as speaker:'
     cancel_event: Cancel event
@@ -2044,6 +2053,7 @@ en:
   title: Title
   titles:
     admin_accounts: List of admin accounts
+    attachments_overview: Attachments overview
     cfp_edit_cfp: Edit Call for Participation
     cfp_new_cfp: Launch a Call for Participation
     cfp_view: Call for Participation

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -228,6 +228,13 @@ es:
     update_successful: "¡Los cambios se guardaron exitosamente!"
   all: Todas
   are_you_sure: "¿Estás seguro?"
+  attachments_overview_module:
+    attachments: archivos adjuntos
+    no_attachments: |
+      Aún no hay archivos adjuntos a ninguno de los eventos. Una vez que la gente
+      comience a subir archivos a sus eventos, podrá
+      ver todos los archivos adjuntos en esta pantalla.
+    no_event: Aún no hay eventos en esta conferencia. Una vez que se agregan los eventos con archivos adjuntos, aparecerán aquí.
   availabilities:
     alerts:
       available_for_day: disponible para el día %{day}
@@ -966,8 +973,10 @@ es:
     add_event_hint: Agrega un nuevo evento.
     add_ticket: Agregar ticket
     add_ticket_hint: Crea un boleto para este evento.
+    ago: hace %{time_ago}
     all_events: Todos los eventos
     all_rating: Todas las calificaciones
+    attachments_overview: Archivos adjuntos
     average_feedback: 'Comentarios promedio:'
     average_speaker_feedback: 'Comentarios promedio como ponente:'
     cancel_event: Cancelar evento
@@ -2078,6 +2087,7 @@ es:
   title: Título
   titles:
     admin_accounts: Lista de cuentas de administrador
+    attachments_overview: Resumen de archivos adjuntos
     cfp_edit_cfp: Editar convocatoria de participación
     cfp_new_cfp: Lanzar una convocatoria de participación
     cfp_view: Llamada para Participación

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -184,6 +184,13 @@ fr:
     update_successful: Modifications sauvegardées.
   all: Tous
   are_you_sure: Êtes-vous sûr(e)?
+  attachments_overview_module:
+    attachments: pièces jointes
+    no_attachments: |
+      Il n'y a pas encore de fichier attaché à aucun des événements. Une fois les gens
+      commencer à télécharger des fichiers à leurs événements, vous pourrez
+      voir toutes les pièces jointes dans cet écran.
+    no_event: Il n'y a pas encore d'événements dans cette conférence. Une fois que les événements comportant des pièces jointes sont ajoutés, ils apparaissent ici.
   availabilities:
     alerts:
       available_for_day: disponible pour le jour %{day}
@@ -945,8 +952,10 @@ fr:
     add_event_hint: Créé un nouvel évènement.
     add_ticket: Ajouter un ticket
     add_ticket_hint: Créé un ticket pour cet évènement.
+    ago: il y a %{time_ago}
     all_events: Tous les évènements
     all_rating: Toutes les notes
+    attachments_overview: Les pièces jointes
     average_feedback: 'Moyenne des retours :'
     average_speaker_feedback: 'Moyenne des retours par orateur :'
     cancel_event: Annuler l’évènement
@@ -2049,6 +2058,7 @@ fr:
   title: Titre
   titles:
     admin_accounts: Liste des comptes administrateur
+    attachments_overview: Aperçu des pièces jointes
     cfp_edit_cfp: Éditer l’appel à participation
     cfp_new_cfp: Lancer un appel à participation
     cfp_view: Appel à participation

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -184,6 +184,13 @@ it:
     update_successful: Modifiche salvate.
   all: Tutti
   are_you_sure: Sei sicuro?
+  attachments_overview_module:
+    attachments: allegati
+    no_attachments: |
+      Non ci sono ancora file allegati a nessuno degli eventi. Una volta le persone
+      iniziare a caricare i file ai loro eventi, sarai in grado di farlo
+      vedere tutti gli allegati in questa schermata.
+    no_event: Non ci sono ancora eventi in questa conferenza. Una volta aggiunti gli eventi con file allegati, verranno visualizzati qui.
   availabilities:
     alerts:
       available_for_day: disponibile per il giorno %{day}
@@ -949,8 +956,10 @@ it:
     add_event_hint: Crea un nuovo evento.
     add_ticket: Aggiungi un biglietto
     add_ticket_hint: Crea un ticket per questo evento.
+    ago: "%{time_ago} fa"
     all_events: Tutti gli eventi
     all_rating: Tutte le note
+    attachments_overview: allegati
     average_feedback: 'Rendimenti medi:'
     average_speaker_feedback: 'Rendimenti medi per oratore:'
     cancel_event: Annulla l'evento
@@ -2053,6 +2062,7 @@ it:
   title: titolo
   titles:
     admin_accounts: Elenco di account amministratore
+    attachments_overview: Panoramica sugli allegati
     cfp_edit_cfp: Modifica l'invito per la partecipazione
     cfp_new_cfp: Avvia un invito alla partecipazione
     cfp_view: Invito alla partecipazione

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -206,6 +206,13 @@ pt-BR:
     update_successful: Alterações salvas com sucesso!
   all: Todos
   are_you_sure: Você tem certeza?
+  attachments_overview_module:
+    attachments: acessórios
+    no_attachments: |
+      Ainda não há arquivos anexados a nenhum dos eventos. Uma vez que as pessoas
+      começar a enviar arquivos para seus eventos, você poderá
+      veja todos os anexos nesta tela.
+    no_event: Ainda não há eventos nesta conferência. Depois que os eventos com anexos de arquivo forem adicionados, eles aparecerão aqui.
   availabilities:
     alerts:
       available_for_day: disponível para o dia %{day}
@@ -934,8 +941,10 @@ pt-BR:
     add_event_hint: Adicione um novo evento.
     add_ticket: Adicionar ticket
     add_ticket_hint: Crie um ticket para este evento.
+    ago: "%{time_ago} atrás"
     all_events: Todos os eventos
     all_rating: Todas as classificações
+    attachments_overview: Anexos
     average_feedback: 'Feedback médio:'
     average_speaker_feedback: 'Feedback médio como palestrante:'
     cancel_event: Cancelar evento
@@ -2062,6 +2071,7 @@ pt-BR:
   title: Título
   titles:
     admin_accounts: Lista de contas de administrador
+    attachments_overview: Visão geral dos anexos
     cfp_edit_cfp: Editar chamada para participação
     cfp_new_cfp: Lançar uma chamada para participação
     cfp_view: Chamada para Participação

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -184,6 +184,13 @@ ru:
     update_successful: Изменения сохранены успешно!
   all: Все
   are_you_sure: Ты уверен?
+  attachments_overview_module:
+    attachments: вложения
+    no_attachments: |
+      Нет файлов, прикрепленных к какому-либо из событий. Когда-то люди
+      начать загружать файлы на свои мероприятия, вы сможете
+      увидеть все вложения на этом экране.
+    no_event: На этой конференции пока нет событий. Как только события с вложенными файлами будут добавлены, они появятся здесь.
   availabilities:
     alerts:
       available_for_day: доступно для дня %{day}
@@ -924,8 +931,10 @@ ru:
     add_event_hint: Добавьте новое событие.
     add_ticket: Добавить билет
     add_ticket_hint: Создайте билет для этого мероприятия.
+    ago: "%{time_ago} назад"
     all_events: Все события
     all_rating: Все рейтинги
+    attachments_overview: Вложения
     average_feedback: 'Средняя оценка:'
     average_speaker_feedback: 'Средняя обратная связь как динамик:'
     cancel_event: Отменить событие
@@ -2026,6 +2035,7 @@ ru:
   title: заглавие
   titles:
     admin_accounts: Список учетных записей администратора
+    attachments_overview: Обзор вложений
     cfp_edit_cfp: Изменить звонок для участия
     cfp_new_cfp: Запуск заявки на участие
     cfp_view: Призыв к участию

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -184,6 +184,13 @@ zh:
     update_successful: 更改已成功保存！
   all: 所有
   are_you_sure: 你确定？
+  attachments_overview_module:
+    attachments: 附件
+    no_attachments: |
+      尚无任何事件附加文件。曾经的人
+      开始将文件上传到他们的活动，您将能够
+      查看此屏幕中的所有附件。
+    no_event: 该会议尚无任何活动。添加带有文件附件的事件后，它们将显示在此处。
   availabilities:
     alerts:
       available_for_day: 可用于一天%{day}
@@ -924,8 +931,10 @@ zh:
     add_event_hint: 添加一个新事件。
     add_ticket: 添加票据
     add_ticket_hint: 为此活动创建一张票。
+    ago: "%{time_ago}之前"
     all_events: 所有事件
     all_rating: 所有评级
+    attachments_overview: 附件
     average_feedback: 平均反馈：
     average_speaker_feedback: 以演讲者的平均反馈：
     cancel_event: 取消活动
@@ -2026,6 +2035,7 @@ zh:
   title: 标题
   titles:
     admin_accounts: 管理员帐户列表
+    attachments_overview: 附件概述
     cfp_edit_cfp: 编辑呼叫参与
     cfp_new_cfp: 发起参与呼吁
     cfp_view: 呼吁参与

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
         collection do
           get :my
           get :ratings
+          get :attachments
           get :feedbacks
           get :start_review
           get :cards

--- a/test/integration/view_event_test.rb
+++ b/test/integration/view_event_test.rb
@@ -26,6 +26,24 @@ class ViewEventTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'can view attachment overview table' do
+    get "/#{@conference.acronym}/events/attachments"
+    assert_includes @response.body, 'There are no files attached'
+    
+    upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'textfile.txt'), 'text/plain')
+    @event.update_attributes( event_attachments_attributes: { 'xx' => { 'title' => 'proposal',         'attachment' => upload } }) #todo join lines?
+    @event.update_attributes( event_attachments_attributes: { 'yy' => { 'title' => 'a freeform title', 'attachment' => upload } })
+                                                                
+    get "/#{@conference.acronym}/events/attachments"
+    assert_includes @response.body, @event.title
+
+    assert_select 'a', 'a freeform title' # freeform titles appear as clickable names
+
+    assert_includes @response.body, 'proposal' # proposal appears as a table header, not a link
+    assert_select 'a', {text: 'proposal', count: 0}
+    
+  end
+
   test 'reports no results for missing terms' do
     get "/#{@conference.acronym}/events?q%5Bs%5D=track_name+asc&term=workshop&utf8=%E2%9C%93"
     assert_response :success


### PR DESCRIPTION
With this view crew can get a look on all the attachments uploaded to
the conference. Attachments with pre-set titles appear in their own
columns and are indicated by the updated date.

see #523