### PR TITLE
present "alert" flash messages in red and "notice" in green

### DIFF
--- a/app/views/shared/_flash.html.haml
+++ b/app/views/shared/_flash.html.haml
@@ -1,5 +1,5 @@
 .flash
   - flash.each do |type, message|
-    %div{class: "alert-message #{type == :notice ? "success" : type.to_s} fade in", "data-alert" => "alert"}
+    %div{class: "alert-message #{ { "notice" => "success", "alert" => "error" }.fetch(type.to_s, type.to_s) } fade in", "data-alert" => "alert"}
       %a.close{href: "#"} ×
       %p= message


### PR DESCRIPTION
:alert was used but not presented in color; and there seem to have been a mismatch of the symbol vs string kind.

Examples:

![image](https://user-images.githubusercontent.com/20379005/66232988-e7fb7000-e6f2-11e9-8ac8-b0e679ecfff9.png)
(together with pull#571 )

![image](https://user-images.githubusercontent.com/20379005/66233053-111c0080-e6f3-11e9-86e1-162605c24a0d.png)


