### PR TITLE
Improved event filters

### DIFF
--- a/app/assets/images/filter_highlight.svg
+++ b/app/assets/images/filter_highlight.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg width="28.347pt" height="28.347pt" fill-rule="evenodd" overflow="visible" stroke-linejoin="bevel" stroke-width=".501" version="1.1" viewBox="0 0 28.347 28.347" xmlns="http://www.w3.org/2000/svg">
+<g transform="scale(1 -1)" fill="none" stroke="#000">
+<g transform="translate(0 -28.347)">
+<g stroke="#0003ff" stroke-linejoin="miter" stroke-miterlimit="79.84">
+<path d="m10.695 14.102-9.03 12.537h24.198l-9.119-12.64v-7.063l-6.049-4.537z" fill="none" stroke-width="1.512"/>
+<path d="m10.695 14.102v-11.703l6.049 4.537v7.063l9.119 12.64h-24.198l9.03-12.537z" fill="#0003ff" stroke-linecap="round" stroke-width=".5"/>
+</g>
+</g>
+</g>
+</svg>

--- a/app/assets/images/filter_off.svg
+++ b/app/assets/images/filter_off.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg width="28.347pt" height="28.347pt" fill-rule="evenodd" overflow="visible" stroke-linejoin="bevel" stroke-width=".501" version="1.1" viewBox="0 0 28.347 28.347" xmlns="http://www.w3.org/2000/svg">
+<g transform="scale(1 -1)" fill="none" stroke="#000">
+<g transform="translate(0 -28.347)">
+<path d="m10.695 14.102-9.03 12.537h24.198l-9.119-12.64v-7.063l-6.049-4.537z" fill="none" stroke="#b2b2b2" stroke-linejoin="miter" stroke-miterlimit="79.84" stroke-width="1.512"/>
+</g>
+</g>
+</svg>

--- a/app/assets/images/filter_on.svg
+++ b/app/assets/images/filter_on.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+<svg width="28.347pt" height="28.347pt" fill-rule="evenodd" overflow="visible" stroke-linejoin="bevel" stroke-width=".501" version="1.1" viewBox="0 0 28.347 28.347" xmlns="http://www.w3.org/2000/svg">
+<g transform="scale(1 -1)" fill="none" stroke="#000">
+<g transform="translate(0 -28.347)">
+<path d="m10.695 14.102-9.03 12.537h24.198l-9.119-12.64v-7.063l-6.049-4.537z" fill="none" stroke="#0003ff" stroke-linejoin="miter" stroke-miterlimit="79.84" stroke-width="1.512"/>
+</g>
+</g>
+</svg>

--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -317,3 +317,8 @@ div.filters-row {
     background: url('filter_highlight.svg');
     background-size: contain;
 }
+
+.filter_form_op div.input {
+    color: red;
+    margin-left: auto;
+}

--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -268,3 +268,30 @@ span.after-deadline.soft {
 span.after-deadline.hard {
     background-color: red;
 }
+
+div.filters-row {
+    margin-bottom: 13px;
+}
+
+.filterbox {
+    margin-left: 10px;
+    margin-right: 10px;
+    border-style: solid;
+    background: #E2E2E2;
+    padding: 4px;
+    border-color: #202020;
+    border-width: thin;
+}
+
+.filterbox-close-btn {
+    background: #222222;
+    padding: 4px;
+    color: #FFFF;
+    margin-left: -4px;
+    margin-right: 7px;
+}
+
+.filterbox-close-btn:hover {
+    color: lightblue;
+    text-decoration: none;
+}

--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -131,6 +131,7 @@ span.right { float: right; }
 
 td.buttons { white-space: nowrap; }
 td.nowrap { white-space: nowrap; }
+th.nowrap { white-space: nowrap; }
 
 a.assoc {
   margin-left: 150px;
@@ -294,4 +295,25 @@ div.filters-row {
 .filterbox-close-btn:hover {
     color: lightblue;
     text-decoration: none;
+}
+
+.filter_icon {
+    display: inline-block;
+    height: 1rem;
+    width: 1rem;
+    vertical-align: bottom;
+}
+
+.filter_icon.true {
+    background: url('filter_on.svg');
+    background-size: contain;
+}
+.filter_icon.false {
+    background: url('filter_off.svg');
+    background-size: contain;
+}
+
+.filter_icon:hover {
+    background: url('filter_highlight.svg');
+    background-size: contain;
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,6 +50,18 @@ class EventsController < BaseConferenceController
     @events = result.paginate page: page_param
   end
 
+  def filter_modal
+    authorize @conference, :read?
+    
+    @filter = helpers.filters_data.detect{|f| f.qname == params[:which_filter]}
+    
+    @options = helpers.localized_filter_options(@conference.events.includes(:track).distinct.pluck(@filter.attribute_name), @filter.i18n_scope)
+    
+    @selected_values = helpers.split_filter_string(params[@filter.qname]) if params[@filter.qname].present?
+    
+    render partial: 'filter_modal'
+  end
+  
   # events as pdf
   def cards
     authorize @conference, :manage?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -268,9 +268,7 @@ class EventsController < BaseConferenceController
     filter = events
     helpers.filters_data.each do |f|
       if params[f.qname].present?
-        if f.type == :text
-          filter = filter.where(f.attribute_name => params[f.qname])
-        end
+        filter = filter.where(f.attribute_name => criteria_from_param(f))
       end
     end
     @search = perform_search(filter, params, %i(title_cont description_cont abstract_cont track_name_cont event_type_is))
@@ -280,7 +278,14 @@ class EventsController < BaseConferenceController
       @search.result(distinct: true)
     end
   end
-  
+
+  def criteria_from_param(f)
+      s = params[f.qname]
+      c = helpers.split_filter_string(s)
+      c += [nil] if c.include?('')
+      return c
+  end
+
   def event_params
     params.require(:event).permit(
       :id, :title, :subtitle, :event_type, :time_slots, :state, :start_time, :public, :language, :abstract, :description, :logo, :track_id, :room_id, :note, :submission_note, :do_not_record, :recording_license, :tech_rider,

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -70,9 +70,9 @@ module EventsHelper
     s.split('|', -1)
   end
 
-  def filter_link(qname)
-    link_to "",'#',
-            class: [ 'show_filter_modal', 'filter_icon', params[qname].present?],
+  def filter_link(qname, text='')
+    link_to text, '#',
+            class: [ 'show_filter_modal', ('filter_icon' unless text.present?), params[qname].present? ] ,
             data: { url: filter_modal_events_url(request.query_parameters.merge(which_filter: qname)) }
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -24,4 +24,32 @@ module EventsHelper
     duration_in_minutes = number_of_time_slots * @conference.timeslot_duration
     duration_to_time(duration_in_minutes)
   end
+
+  FilterData = Struct.new(:type, :attribute_name, :qname, :filter_name_i18n, :filter_name, :i18n_scope)
+
+  def filters_data
+    [ FilterData[:text,
+                 'tracks.name',
+                 'track_name',
+                 'activerecord.attributes.event.track'],
+      FilterData[:text,
+                 :event_type,
+                 'event_type',
+                 'activerecord.attributes.event.event_type',
+                 nil,
+                 'options'],
+      FilterData[:text,
+                 :state,
+                 'event_state',
+                 'activerecord.attributes.event.state',
+                 nil,
+                 'conferences_module'] ].freeze
+  end
+
+  def show_filters_pane?
+    filters_data.each do |f|
+      return true if params[f.qname].present?
+    end
+    false
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -52,4 +52,7 @@ module EventsHelper
     end
     false
   end
+  def split_filter_string(s)
+    s.split('|', -1)
+  end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -43,7 +43,15 @@ module EventsHelper
                  'event_state',
                  'activerecord.attributes.event.state',
                  nil,
-                 'conferences_module'] ].freeze
+                 'conferences_module'],
+      FilterData[:range,
+                  :average_rating,
+                  'average_rating',
+                  'activerecord.attributes.event.average_rating'],
+       FilterData[:range,
+                  :event_ratings_count,
+                  'event_ratings_count',
+                  'activerecord.attributes.event.event_ratings_count'] ].freeze
   end
 
   def show_filters_pane?
@@ -74,5 +82,10 @@ module EventsHelper
     link_to text, '#',
             class: [ 'show_filter_modal', ('filter_icon' unless text.present?), params[qname].present? ] ,
             data: { url: filter_modal_events_url(request.query_parameters.merge(which_filter: qname)) }
+  end
+  
+  def get_op_and_val(str)
+    /^(?<op>[≤≥=]?)(?<val>.*)$/ =~ str
+    return op, val
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -51,7 +51,12 @@ module EventsHelper
        FilterData[:range,
                   :event_ratings_count,
                   'event_ratings_count',
-                  'activerecord.attributes.event.event_ratings_count'] ].freeze
+                  'activerecord.attributes.event.event_ratings_count'] ].freeze +
+       @conference.review_metrics.map{ |rm| FilterData[:range,
+                                                      "#{rm.safe_name}.score",
+                                                      rm.safe_name,
+                                                      nil,
+                                                      rm.name] }
   end
 
   def show_filters_pane?

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -52,7 +52,27 @@ module EventsHelper
     end
     false
   end
+  def localized_filter_options(c, i18n_scope)
+    c = split_filter_string(c) if c.is_a? String
+    options = (c - ['',nil]).map{|v| [ if i18n_scope 
+                                         t(v, scope: i18n_scope, default: v)
+                                       else  
+                                         v
+                                       end,
+                                       v]    }.sort
+    if c.include? '' or c.include? nil
+      options.push [ t('blank_indication'), '' ]
+    end
+    options
+  end
+  
   def split_filter_string(s)
     s.split('|', -1)
+  end
+
+  def filter_link(qname)
+    link_to "",'#',
+            class: [ 'show_filter_modal', 'filter_icon', params[qname].present?],
+            data: { url: filter_modal_events_url(request.query_parameters.merge(which_filter: qname)) }
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -39,7 +39,7 @@ class Conference < ApplicationRecord
     :expenses_enabled,
     :transport_needs_enabled,
     :bulk_notification_enabled, inclusion: { in: [true, false] }
-  validates :allowed_event_types_as_list, presence: { message: :blank }
+  validates :allowed_event_types_as_list, presence: { message: :blank }, format: { without: /\|/ }
   validates :acronym, uniqueness: true
   validates :acronym, format: { with: /\A[a-z0-9_-]*\z/ }
   validates :color, format: { with: /\A[a-zA-Z0-9]*\z/ }

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -10,6 +10,7 @@ class Track < ApplicationRecord
 
   validates :color, format: { with: /\A[a-zA-Z0-9]*\z/ }
   validates :name, presence: true
+  validates :name, format: { without: /\|/ }
 
   def to_s
     "#{model_name.human}: #{name}"

--- a/app/views/events/_filter_modal.html.haml
+++ b/app/views/events/_filter_modal.html.haml
@@ -1,0 +1,37 @@
+.modal-header
+  = link_to "×", "#", class: "close"
+  %h3
+    = t('events_module.select_filter_for', filtername: @filter.filter_name || t(@filter.filter_name_i18n))
+.modal-body#filter_form
+  = simple_form_for(:filter_form, data: { qname: @filter.qname }, url: '#', method: :get ) do |f|
+    %div#filter-values-select
+      = f.input :possible_values,
+                as: :check_boxes, 
+                label: '',
+                required: false,
+                collection: @options,
+                checked: @selected_values
+  
+    .actions
+      = link_to t('apply_filter'), '#', class: "btn primary", id: 'apply_filter_btn'
+.modal-footer
+  &nbsp;
+
+:coffeescript
+  $('#apply_filter_btn').on 'click', (event) -> 
+    qname = $('#filter_form form').data('qname')
+
+    new_value=''
+    if $("#filter-values-select").length
+      selected_vals = []
+      for a in $("#filter-values-select input:checked")
+        selected_vals.push(a.value) 
+      new_value = selected_vals.join('|')
+    u = new URL(location.href)
+    u.searchParams.set(qname, new_value)
+    $("#apply_filter_btn").attr("href", u.toString())
+    $('#filters-modal').modal('hide')
+    true
+  
+
+  

--- a/app/views/events/_filter_modal.html.haml
+++ b/app/views/events/_filter_modal.html.haml
@@ -14,6 +14,7 @@
   
     .actions
       = link_to t('apply_filter'), '#', class: "btn primary", id: 'apply_filter_btn'
+      = link_to t('clear_filter'), '#', class: "btn",         id: 'clear_filter_btn'
 .modal-footer
   &nbsp;
 
@@ -30,6 +31,14 @@
     u = new URL(location.href)
     u.searchParams.set(qname, new_value)
     $("#apply_filter_btn").attr("href", u.toString())
+    $('#filters-modal').modal('hide')
+    true
+  
+  $('#clear_filter_btn').on 'click', (event) -> 
+    qname = $('#filter_form form').data('qname')
+    u = new URL(location.href)
+    u.searchParams.delete(qname)
+    $("#clear_filter_btn").attr("href", u.toString())
     $('#filters-modal').modal('hide')
     true
   

--- a/app/views/events/_filter_modal.html.haml
+++ b/app/views/events/_filter_modal.html.haml
@@ -4,14 +4,31 @@
     = t('events_module.select_filter_for', filtername: @filter.filter_name || t(@filter.filter_name_i18n))
 .modal-body#filter_form
   = simple_form_for(:filter_form, data: { qname: @filter.qname }, url: '#', method: :get ) do |f|
-    %div#filter-values-select
-      = f.input :possible_values,
-                as: :check_boxes, 
-                label: '',
-                required: false,
-                collection: @options,
-                checked: @selected_values
-  
+    - case @filter.type
+    - when :text
+      %div#filter-values-select
+        = f.input :possible_values,
+                  as: :check_boxes, 
+                  label: '',
+                  required: false,
+                  collection: @options,
+                  checked: @selected_values
+    - when :range
+      %div#filter-range
+        %table{width: '100%'}   
+          %tr
+            %td{ style: 'vertical-align: middle;', 'max-width': '25%' }
+              = f.input :op,
+                      as: :radio_buttons,
+                      required: false,
+                        label: '',
+                      collection: [['≥', '≥'],
+                                   ['≤', '≤'],
+                                   ['=', '=']],
+                      checked: [@op]
+                    
+            %td{width: '75%', style: 'vertical-align: middle;', class: 'td-numval'}
+              = f.input_field :num, value: @current_numeric_value, style: "width: 150px;"
     .actions
       = link_to t('apply_filter'), '#', class: "btn primary", id: 'apply_filter_btn'
       = link_to t('clear_filter'), '#', class: "btn",         id: 'clear_filter_btn'
@@ -28,6 +45,10 @@
       for a in $("#filter-values-select input:checked")
         selected_vals.push(a.value) 
       new_value = selected_vals.join('|')
+    if $("#filter-range input").length
+      op = $("#filter-range input:checked").val()
+      refval = parseFloat($(".td-numval input").val())
+      new_value = op + refval unless !op or isNaN(refval)
     u = new URL(location.href)
     u.searchParams.set(qname, new_value)
     $("#apply_filter_btn").attr("href", u.toString())

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -1,15 +1,13 @@
-- if params[:event_type].present? or params[:event_state].present? or params[:track_name].present?
+- if show_filters_pane?
   %p
     %b= t('col_filters')
-    %span{:style => 'margin-left: 1em'}
-      - if params[:track_name].present?
-        = link_to "[x]", request.query_parameters.except(:track_name)
-        track name: #{params[:track_name]}
-    %span{:style => 'margin-left: 1em'}
-      - if params[:event_type].present?
-        = link_to "[x]", request.query_parameters.except(:event_type)
-        event type: #{params[:event_type]}
-    %span{:style => 'margin-left: 1em'}
-      - if params[:event_state].present?
-        = link_to "[x]", request.query_parameters.except(:event_state)
-        event state: #{params[:event_state]}
+    - filters_data.each do |f|
+      - if params[f.qname].present?
+        %span{:style => 'margin-left: 1em'}
+          = link_to "[x]", request.query_parameters.except(f.qname)
+          = f.filter_name || t(f.filter_name_i18n)
+          = ":"
+          - if f.i18n_scope
+            = t(params[f.qname], scope: f.i18n_scope)
+          - else
+            = params[f.qname]

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -7,7 +7,9 @@
           = link_to "╳", request.query_parameters.except(f.qname), class: 'filterbox-close-btn'
           = f.filter_name || t(f.filter_name_i18n)
           = ":"
-          - if f.i18n_scope
-            = t(params[f.qname], scope: f.i18n_scope)
-          - else
-            = params[f.qname]
+          - options_selected = localized_filter_options(params[f.qname], f.i18n_scope)
+          - if options_selected.count == 1
+            - w = options_selected[0].first
+          - else 
+            - w = t('multiple_indication')
+          = filter_link(f.qname, w)

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -1,10 +1,10 @@
 - if show_filters_pane?
-  %p
+  %div.filters-row
     %b= t('col_filters')
     - filters_data.each do |f|
       - if params[f.qname].present?
-        %span{:style => 'margin-left: 1em'}
-          = link_to "[x]", request.query_parameters.except(f.qname)
+        %span{:class => 'filterbox'}
+          = link_to "╳", request.query_parameters.except(f.qname), class: 'filterbox-close-btn'
           = f.filter_name || t(f.filter_name_i18n)
           = ":"
           - if f.i18n_scope

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -6,10 +6,14 @@
         %span{:class => 'filterbox'}
           = link_to "╳", request.query_parameters.except(f.qname), class: 'filterbox-close-btn'
           = f.filter_name || t(f.filter_name_i18n)
-          = ":"
-          - options_selected = localized_filter_options(params[f.qname], f.i18n_scope)
-          - if options_selected.count == 1
-            - w = options_selected[0].first
-          - else 
-            - w = t('multiple_indication')
-          = filter_link(f.qname, w)
+          - op,val=get_op_and_val(params[f.qname])
+          - if f.type == :range and op.present?
+            = filter_link(f.qname, "#{op} #{val}")
+          - else  
+            = ":"
+            - options_selected = localized_filter_options(params[f.qname], f.i18n_scope)
+            - if options_selected.count == 1
+              - w = options_selected[0].first
+            - else 
+              - w = t('multiple_indication')
+            = filter_link(f.qname, w)

--- a/app/views/events/_filters_modal_holder.html.haml
+++ b/app/views/events/_filters_modal_holder.html.haml
@@ -1,0 +1,21 @@
+#filters-modal.modal{style: "display: none;"}
+
+:coffeescript
+  update_filter_modal = (url) ->
+    $.ajax(
+      dataType: "html",
+      url: url,
+      success: (data) ->
+        $('#filters-modal').modal('show')
+        $('#filters-modal').html(data)
+      error: () ->
+        location.reload(true)
+    )
+    
+  $('.show_filter_modal').on 'click', -> 
+    update_filter_modal(this.dataset['url'])
+     
+  $("#filters-modal").draggable({
+    handle: ".modal-header"
+  }); 
+  

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -39,9 +39,9 @@
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
         %td= link_to_unless (params[:track_name].present? or event.track.nil?), event.track.try(:name), request.query_parameters.merge(:track_name => event.track.try(:name))
-        %td= link_to_unless params[:event_type].present?, event.event_type, request.query_parameters.merge(:event_type => event.event_type)
+        %td= link_to_unless params[:event_type].present?, (t(event.event_type, scope: 'options') unless event.event_type.blank?).to_s, request.query_parameters.merge(:event_type => event.event_type)
         - if policy(@conference).manage?
-          %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
+          %td= link_to_unless params[:event_state].present?, (t(event.state, scope: 'conferences_module') unless event.state.blank?).to_s, request.query_parameters.merge(:event_state => event.state)
         %td
           %span.nowrap= l(event.date_of_submission_in_conference_tz)
           = render partial: 'events/event_tags', locals: { event: event, short: true }

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -6,10 +6,16 @@
         %th= sort_link @search, :title, t('title'), term: params[:term]
         - if @conference.ticket_server_enabled?
           %th= sort_link @search, :ticket_id, t('ticket'), term: params[:term]
-        %th= sort_link @search, :track_name, t('track'), term: params[:term]
-        %th= sort_link @search, :event_type, t('type'), term: params[:term]
+        %th.nowrap
+          = sort_link @search, :track_name, t('track'), term: params[:term]
+          = filter_link('track_name')
+        %th.nowrap
+          = sort_link @search, :event_type, t('type'), term: params[:term]
+          = filter_link 'event_type'
         - if policy(@conference).manage?
-          %th= sort_link @search, :state, t('state'), term: params[:term]
+          %th.nowrap
+            = sort_link @search, :state, t('state'), term: params[:term]
+            = filter_link 'event_state'
         %th= sort_link @search, t('created_at'), term: params[:term]
       - else
         %th= t('title')
@@ -52,3 +58,4 @@
             = action_button "small danger", t('destroy'), event, data: { confirm: t('are_you_sure')}, method: :delete
           - elsif current_user.is_speaker_in?(event)
             = action_button "small", t('edit'), edit_cfp_event_path(event)
+= render partial: 'events/filters_modal_holder'

--- a/app/views/events/attachments.html.haml
+++ b/app/views/events/attachments.html.haml
@@ -31,10 +31,16 @@
               %tr
                 %th
                 %th= sort_link @search, :title, term: params[:term]
-                %th= sort_link @search, :track_name, t('track'), term: params[:term]
-                %th= sort_link @search, :event_type, term: params[:term]
+                %th.nowrap
+                  = sort_link @search, :track_name, t('track'), term: params[:term]
+                  = filter_link('track_name')
+                %th.nowrap
+                  = sort_link @search, :event_type, term: params[:term]
+                  = filter_link('event_type')
                 - if policy(@conference).manage?
-                  %th= sort_link @search, :state, term: params[:term]
+                  %th.nowrap
+                    = sort_link @search, :state, term: params[:term]
+                    = filter_link('event_state')
                 - @attachment_titles.each do |attachment_title|
                   %th= t(attachment_title, scope: 'events_module.predefined_title_types')
                 - if @other_attachment_titles_exist
@@ -57,3 +63,4 @@
                     %td= safe_join( event.event_attachments.where.not(title: @attachment_titles).map{|ea| link_to ea.link_title, ea.attachment.url}, '<br>'.html_safe )
           = actions_bar do
             = will_paginate @events
+= render partial: 'filters_modal_holder'

--- a/app/views/events/my.html.haml
+++ b/app/views/events/my.html.haml
@@ -15,4 +15,5 @@
           %p= t('events_module.not_involved')
 
   - else
+    = render partial: 'filters', locals: { params: params }
     = render 'shared/search_and_table', collection: @events

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -43,10 +43,16 @@
               %tr
                 %th
                 %th= sort_link @search, :title, term: params[:term]
-                %th= sort_link @search, :track_name, t('track'), term: params[:term]
-                %th= sort_link @search, :event_type, term: params[:term]
+                %th.nowrap
+                  = sort_link @search, :track_name, t('track'), term: params[:term]
+                  = filter_link('track_name')
+                %th.nowrap
+                  = sort_link @search, :event_type, term: params[:term]
+                  = filter_link('event_type')
                 - if policy(@conference).manage?
-                  %th= sort_link @search, :state, term: params[:term]
+                  %th.nowrap
+                    = sort_link @search, :state, term: params[:term]
+                    = filter_link('event_state')
                 %th= sort_link @search, :average_rating, term: params[:term]
                 %th= sort_link @search, :event_ratings_count, term: params[:term]
                 - review_metrics.each do |review_metric|
@@ -75,4 +81,4 @@
                     = link_to t('ratings_module.show_ratings'), event_event_rating_path(event), class: "btn small"
           = actions_bar do
             = will_paginate @events
-
+= render partial: 'filters_modal_holder'

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -53,8 +53,12 @@
                   %th.nowrap
                     = sort_link @search, :state, term: params[:term]
                     = filter_link('event_state')
-                %th= sort_link @search, :average_rating, term: params[:term]
-                %th= sort_link @search, :event_ratings_count, term: params[:term]
+                %th.nowrap
+                  = sort_link @search, :average_rating, term: params[:term]
+                  = filter_link('average_rating')
+                %th
+                  = sort_link @search, :event_ratings_count, term: params[:term]
+                  = filter_link('event_ratings_count')
                 - review_metrics.each do |review_metric|
                   %th= sort_link @search, review_metric.safe_name, review_metric.name, term: params[:term]
                 %th
@@ -72,8 +76,8 @@
                     %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
                   %td
                     - if event.average_rating
-                      = raty_for("event_rating_#{event.id}", event.average_rating)
-                  %td= event.event_ratings_count
+                      = link_to_unless params[:average_rating].present?, raty_for("event_rating_#{event.id}", event.average_rating), request.query_parameters.merge(:average_rating => "≥#{event.average_rating}")
+                  %td= link_to_unless params[:event_ratings_count].present?, event.event_ratings_count, request.query_parameters.merge(:event_ratings_count => "≥#{event.event_ratings_count}")
                   - review_metrics.each do |review_metric|
                     - avg = event[review_metric.safe_name]
                     %td= avg.round(2) unless avg.nil?

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -60,7 +60,9 @@
                   = sort_link @search, :event_ratings_count, term: params[:term]
                   = filter_link('event_ratings_count')
                 - review_metrics.each do |review_metric|
-                  %th= sort_link @search, review_metric.safe_name, review_metric.name, term: params[:term]
+                  %th
+                    = sort_link @search, review_metric.safe_name, review_metric.name, term: params[:term]
+                    = filter_link(review_metric.safe_name)
                 %th
             %tbody
               - @events.includes(:track).each do |event|
@@ -80,7 +82,9 @@
                   %td= link_to_unless params[:event_ratings_count].present?, event.event_ratings_count, request.query_parameters.merge(:event_ratings_count => "≥#{event.event_ratings_count}")
                   - review_metrics.each do |review_metric|
                     - avg = event[review_metric.safe_name]
-                    %td= avg.round(2) unless avg.nil?
+                    %td
+                      - unless avg.nil?
+                        = link_to_unless params[review_metric.safe_name].present?, avg.round(2), request.query_parameters.merge(review_metric.safe_name => "≥#{avg}")
                   %td
                     = link_to t('ratings_module.show_ratings'), event_event_rating_path(event), class: "btn small"
           = actions_bar do

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1651,6 +1651,7 @@ de:
   manage_conference: Verwalten Sie diese Konferenz
   manual: Handbuch
   more: Mehr...
+  multiple_indication: mehrere
   name: Name
   navigation:
     back: Zurück

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -216,6 +216,7 @@ de:
   all: Alle
   allowed_event_types: Zulässige Ereignistypen
   allowed_event_types_extras: Zusätzliche zulässige Ereignistypen
+  apply_filter: Filter anwenden
   are_you_sure: Sind Sie sicher?
   attachments_overview_module:
     attachments: Anhänge
@@ -237,6 +238,7 @@ de:
   availability: Verfügbarkeit
   available: Verfügbar
   basic_information: Basisinformationen
+  blank_indication: "(leer)"
   by: von
   call_for_participation: Call for Participation
   cancel: Abbrechen
@@ -1071,6 +1073,7 @@ de:
       E-Mail oder gegebenenfalls später im Ticket-System informiert.
     reject_event_no_email: Event rejecten (ohne E-Mail)
     reject_event_no_email_hint: Setzt den Status des Events auf rejected, ohne eine automatisierte E-Mail zu senden.
+    select_filter_for: "Filter für %{filtername} auswählen:"
     toggle_description: Beschreibung umschalten >>
     track_select: Filter nach Track
   expenses: Spesen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,7 @@ en:
   all: All
   allowed_event_types: Allowed event types
   allowed_event_types_extras: Additional allowed event types
+  apply_filter: Apply filter
   are_you_sure: Are you sure?
   attachments_overview_module:
     attachments: attachments
@@ -209,6 +210,7 @@ en:
   availability: Availability
   available: Available
   basic_information: Basic informations
+  blank_indication: (blank)
   by: by
   call_for_participation: Call for Participation
   cancel: Cancel
@@ -1062,6 +1064,7 @@ en:
     reject_event_hint: Reject this event. The speaker(s) will be notified of the rejection via email.
     reject_event_no_email: Reject event (no email)
     reject_event_no_email_hint: Reject this event without sending an automated email.
+    select_filter_for: "Select filter for %{filtername}:"
     toggle_description: Toggle Description >>
     track_select: filter by track
   expenses: Expenses

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1632,6 +1632,7 @@ en:
   manage_conference: Manage this conference
   manual: Manual
   more: More...
+  multiple_indication: multiple
   name: Name
   navigation:
     back: Back

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1685,6 +1685,7 @@ es:
   manage_conference: Administrar esta conferencia
   manual: Manual
   more: Más...
+  multiple_indication: múltiple
   name: Nombre
   navigation:
     back: Espalda

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -232,6 +232,7 @@ es:
   all: Todas
   allowed_event_types: Tipos de eventos permitidos
   allowed_event_types_extras: Tipos de eventos permitidos adicionales
+  apply_filter: Aplicar filtro
   are_you_sure: "¿Estás seguro?"
   attachments_overview_module:
     attachments: archivos adjuntos
@@ -253,6 +254,7 @@ es:
   availability: Disponibilidad
   available: Disponible
   basic_information: Información básica
+  blank_indication: "(blanco)"
   by: por
   call_for_papers: Convocatoria
   call_for_participation: Llamada para Participación
@@ -1110,6 +1112,7 @@ es:
     reject_event_hint: Rechazar este evento El o los oradores serán notificados del rechazo por correo electrónico.
     reject_event_no_email: Rechazar evento (sin correo electrónico)
     reject_event_no_email_hint: Rechace este evento sin enviar un correo electrónico automático.
+    select_filter_for: 'Seleccionar filtro para %{filtername}:'
     toggle_description: Alternar Descripción >>
     track_select: filtrar por la pista
   expenses: Gastos

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1659,6 +1659,7 @@ fr:
   manage_conference: Gérer cette conférence
   manual: Manuel
   more: Plus…
+  multiple_indication: plusieurs
   name: Nom
   navigation:
     back: Retour

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -188,6 +188,7 @@ fr:
   all: Tous
   allowed_event_types: Types d'événements autorisés
   allowed_event_types_extras: Types d'événements autorisés supplémentaires
+  apply_filter: Appliquer le filtre
   are_you_sure: Êtes-vous sûr(e)?
   attachments_overview_module:
     attachments: pièces jointes
@@ -209,6 +210,7 @@ fr:
   availability: Disponibilité
   available: Disponible
   basic_information: Informations de base
+  blank_indication: "(Vide)"
   by: par
   call_for_participation: Appel à participation
   cancel: Annuler
@@ -1088,6 +1090,7 @@ fr:
     reject_event_hint: Rejette cet évènement. Les orateurs seront notifiés de ce rejet par courriel.
     reject_event_no_email: Rejeter l’évènement (pas de courriel)
     reject_event_no_email_hint: Rejeter cet évènement sans envoyer de courriel automatique.
+    select_filter_for: 'Sélectionnez le filtre pour %{filtername}:'
     toggle_description: Afficher la description >>
     track_select: filtrer par fil
   expenses: Dépenses

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -188,6 +188,7 @@ it:
   all: Tutti
   allowed_event_types: Tipi di eventi consentiti
   allowed_event_types_extras: Altri tipi di eventi consentiti
+  apply_filter: Applica il filtro
   are_you_sure: Sei sicuro?
   attachments_overview_module:
     attachments: allegati
@@ -209,6 +210,7 @@ it:
   availability: disponibilità
   available: disponibile
   basic_information: Informazioni di base
+  blank_indication: "(Vuoto)"
   by: da
   call_for_participation: Invito alla partecipazione
   cancel: annullare
@@ -1092,6 +1094,7 @@ it:
     reject_event_hint: Rifiuta questo evento. I relatori saranno informati di questo rifiuto via e-mail.
     reject_event_no_email: Rifiuta l'evento (nessuna email)
     reject_event_no_email_hint: Rifiuta questo evento senza inviare un'e-mail automatica.
+    select_filter_for: 'Seleziona il filtro per %{filtername}:'
     toggle_description: Mostra descrizione >>
     track_select: filtro per filo
   expenses: la spesa

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1663,6 +1663,7 @@ it:
   manage_conference: Gestisci questa conferenza
   manual: manuale
   more: Più ...
+  multiple_indication: multiplo
   name: Nome
   navigation:
     back: ritorno

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -210,6 +210,7 @@ pt-BR:
   all: Todos
   allowed_event_types: Tipos de eventos permitidos
   allowed_event_types_extras: Tipos de eventos adicionais permitidos
+  apply_filter: Aplicar filtro
   are_you_sure: Você tem certeza?
   attachments_overview_module:
     attachments: acessórios
@@ -231,6 +232,7 @@ pt-BR:
   availability: Disponibilidade
   available: acessível
   basic_information: Informações básicas
+  blank_indication: "(em branco)"
   by: de
   call_for_participation: Chamada de Trabalhos
   cancel: Cancelar
@@ -1078,6 +1080,7 @@ pt-BR:
     reject_event_hint: Rejeite este evento. O (s) orador (es) será notificado (a) da rejeição por email.
     reject_event_no_email: Rejeitar evento (sem email)
     reject_event_no_email_hint: Rejeite este evento sem enviar um email automático.
+    select_filter_for: 'Selecione o filtro para %{filtername}:'
     toggle_description: Alternar Descrição >>
     track_select: filtrar por faixa
   expenses: Despesas

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1659,6 +1659,7 @@ pt-BR:
   manage_conference: Gerenciar esta conferência
   manual: Manual
   more: Mais...
+  multiple_indication: múltiplo
   name: Nome
   navigation:
     back: Costas

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1638,6 +1638,7 @@ ru:
   manage_conference: Управление этой конференцией
   manual: Руководство
   more: Больше...
+  multiple_indication: множественный
   name: имя
   navigation:
     back: назад

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -188,6 +188,7 @@ ru:
   all: Все
   allowed_event_types: Разрешенные типы событий
   allowed_event_types_extras: Дополнительные разрешенные типы событий
+  apply_filter: Применить фильтр
   are_you_sure: Ты уверен?
   attachments_overview_module:
     attachments: вложения
@@ -209,6 +210,7 @@ ru:
   availability: Доступность
   available: Доступный
   basic_information: Основные сведения
+  blank_indication: "(Пусто)"
   by: от
   call_for_participation: Призыв к участию
   cancel: Отмена
@@ -1068,6 +1070,7 @@ ru:
     reject_event_hint: Отклонить это событие. Оратор (ы) будет уведомлен об отказе по электронной почте.
     reject_event_no_email: Отклонить событие (без электронной почты)
     reject_event_no_email_hint: Отклоните это событие, не отправляя автоматическое письмо.
+    select_filter_for: 'Выберите фильтр для %{filtername}:'
     toggle_description: Toggle Описание >>
     track_select: фильтр по треку
   expenses: Затраты

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -188,6 +188,7 @@ zh:
   all: 所有
   allowed_event_types: 允许的事件类型
   allowed_event_types_extras: 其他允许的事件类型
+  apply_filter: 套用筛选器
   are_you_sure: 你确定？
   attachments_overview_module:
     attachments: 附件
@@ -209,6 +210,7 @@ zh:
   availability: 可用性
   available: 可得到
   basic_information: 基本信息
+  blank_indication: "（空白）"
   by: 通过
   call_for_participation: 呼吁参与
   cancel: 取消
@@ -1068,6 +1070,7 @@ zh:
     reject_event_hint: 拒绝此事件。发言者将通过电子邮件通知拒绝。
     reject_event_no_email: 拒绝活动(无电子邮件)
     reject_event_no_email_hint: 拒绝此事件而不发送自动电子邮件。
+    select_filter_for: 为%{filtername}选择过滤器：
     toggle_description: 切换说明>>
     track_select: 按轨道过滤
   expenses: 花费

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1638,6 +1638,7 @@ zh:
   manage_conference: 管理这个会议
   manual: 手册
   more: 更多...
+  multiple_indication: 多
   name: 名称
   navigation:
     back: 背部

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,7 @@ Rails.application.routes.draw do
           get :export_all
           get :export_accepted
           get :export_confirmed
+          get :filter_modal
         end
         member do
           get :people

--- a/test/features/editing_event_review_test.rb
+++ b/test/features/editing_event_review_test.rb
@@ -32,6 +32,11 @@ class EditingEventReviewTest < FeatureTest
      assert_content page, REVIEW_METRIC_NAME 
      assert_content page, '3.75' # average([2,4,4,5])
 
+     # Test that filtering by review metric works
+     click_on '3.75'
+     assert_content page, '≥ 3.75'
+     assert_content page, @event.title
+
      # Test that when @user deletes the review, the average is updated correctly
      visit "/#{@conference.acronym}/events/#{@event.id}/event_rating"
      click_on 'Delete Event rating'

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -26,4 +26,13 @@ class EditingEventRatingTest < FeatureTest
     refute_content page, @event2.title
     refute_content page, @event3.title
   end
+  
+  it 'can filter event list by using the multi-filter', js: true do
+    sign_in_user(@user)
+    visit "/#{@conference.acronym}/events?event_type=film|dance"
+    
+    assert_content page, @event1.title
+    refute_content page, @event2.title
+    assert_content page, @event3.title
+  end
 end

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class EditingEventRatingTest < FeatureTest
+  setup do
+    @conference = create(:three_day_conference_with_events)
+    @coordinator = create(:conference_coordinator, conference: @conference)
+    @user = @coordinator.user
+
+    @event1 = @conference.events[0]
+    @event2 = @conference.events[1]
+    @event3 = @conference.events[2]
+    @event1.update_attributes(event_type: 'film')
+    @event2.update_attributes(event_type: 'lecture')
+    @event3.update_attributes(event_type: 'dance')
+
+    EventRating.create(event: @event2, person: @coordinator.person, rating: 3, comment: "comment1")
+  end
+
+  it 'can filter event list by clicking a term', js: true do
+    sign_in_user(@user)
+    visit "/#{@conference.acronym}/events/"
+    
+    click_on 'Film'
+    assert_content page, '[x] Event type : Film'
+    assert_content page, @event1.title
+    refute_content page, @event2.title
+    refute_content page, @event3.title
+  end
+end

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -29,6 +29,18 @@ class EditingEventRatingTest < FeatureTest
   
   it 'can filter event list by using the multi-filter', js: true do
     sign_in_user(@user)
+    visit "/#{@conference.acronym}/events/"
+    
+    # click the filter icon next to table header "Type"
+    find('th', text: 'Type').find('.show_filter_modal').trigger('click')
+    assert_content page, 'Select filter for'
+    
+    check 'Film'
+    check 'dance'
+    
+    find('#apply_filter_btn')
+    # TODO - this fails because phantomjs does not support URL.searchParams.set
+    # click_on 'Apply filter'
     visit "/#{@conference.acronym}/events?event_type=film|dance"
     
     assert_content page, @event1.title

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -21,7 +21,7 @@ class EditingEventRatingTest < FeatureTest
     visit "/#{@conference.acronym}/events/"
     
     click_on 'Film'
-    assert_content page, '[x] Event type : Film'
+    assert_content page, '╳ Event type : Film'
     assert_content page, @event1.title
     refute_content page, @event2.title
     refute_content page, @event3.title

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -26,7 +26,17 @@ class EditingEventRatingTest < FeatureTest
     refute_content page, @event2.title
     refute_content page, @event3.title
   end
-  
+
+  it 'can filter event list by clicking a number', js: true do
+    sign_in_user(@user)
+    visit "/#{@conference.acronym}/events/ratings"
+    find('a', text: /^1$/).click
+    assert_content page, '╳ Event ratings count ≥ 1'
+    refute_content page, @event1.title
+    assert_content page, @event2.title
+    refute_content page, @event3.title
+  end
+
   it 'can filter event list by using the multi-filter', js: true do
     sign_in_user(@user)
     visit "/#{@conference.acronym}/events/"

--- a/test/features/filtering_event_list.rb
+++ b/test/features/filtering_event_list.rb
@@ -43,6 +43,8 @@ class EditingEventRatingTest < FeatureTest
     # click_on 'Apply filter'
     visit "/#{@conference.acronym}/events?event_type=film|dance"
     
+    assert_content page, '╳ Event type : multiple'
+
     assert_content page, @event1.title
     refute_content page, @event2.title
     assert_content page, @event3.title


### PR DESCRIPTION
This PR adds a few improvements to filterings.

1. Add filtering for numeric values  i.e., average rating, number of ratings, average review score.



2. The tables and the "filters" pane are now subject to i18n

![image](https://user-images.githubusercontent.com/20379005/66394762-972f9400-e9de-11e9-9387-0bdf6eaf6cf4.png)

3. For text filters - capability to filter several options together; i.e., show all events in "rejected" and "rejecting" state.


![image](https://user-images.githubusercontent.com/20379005/67641711-ed706280-f90c-11e9-8968-94850484fd76.png)


4. Harmonization of the filter logic so the same code is re-used.

5. Format change for the active filter list.  Clicking on the filter opens the modal filter editor (for both text and numeric filters)

![image](https://user-images.githubusercontent.com/20379005/68059132-f5ad1100-fd03-11e9-9724-beb7ee55f9dc.png)

![image](https://user-images.githubusercontent.com/20379005/68059134-f8a80180-fd03-11e9-9e9f-10f7d25aec85.png)

6. Filter icon in the table headers - gray if not used (not being filtered by this coloumn) ; blue outline if being filters with this coloumn. It changes color to full blue when hovering the mouse, as an invitation to click.

I rewrote everything in this PR and edited it in steps so it should be easier to review.