### PR TITLE
Test for LDAP integration

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,13 @@
 FRAB_HOST=frab.test
 FRAB_PROTOCOL=http
 FROM_EMAIL=frab@frab.test
+NAME_FOR_LDAP=free testing server at ldap.forumsys.com
+LDAP_PROMPT_TITLE=Login as gauss or tesla. password is 'password'.
+LDAP_HOST=ldap.forumsys.com
+LDAP_PORT=389
+LDAP_METHOD=plain
+LDAP_BASE_DN=dc=example,dc=com
+LDAP_UID=uid
+LDAP_FILTER=
+LDAP_BIND_DN=
+LDAP_BIND_PASSWORD=

--- a/test/features/ldap_test.rb
+++ b/test/features/ldap_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class LdapTest < FeatureTest
+  LOGIN='tesla'     # see https://www.forumsys.com/category/tutorials/integration-how-to/
+  PASSWORD='password'
+  EMAIL='tesla@ldap.forumsys.com'
+
+  setup do
+    assert User.where(email: EMAIL).blank?
+  end
+
+  def connect_with_ldap
+    visit '/'
+   
+    click_on 'Log-in'
+   
+    click_on 'Sign in with free testing server at ldap.forumsys.com'
+   
+    fill_in 'Login:', with: LOGIN
+    fill_in 'Password:', with: PASSWORD
+    click_on 'Sign In'
+   
+    assert_content page, 'Successfully authenticated'
+    assert User.where(email: EMAIL).any?
+    
+    click_on 'Logout'
+  end
+
+  test 'can sign up and sign in with LDAP' do
+    connect_with_ldap # for new user
+    connect_with_ldap # for existing user
+  end
+  
+  teardown do
+    User.where(email: EMAIL).destroy_all
+  end
+end


### PR DESCRIPTION
This PR adds an automatic test for LDAP integration (ref #17 and https://github.com/frab/frab/pull/502).

The test is directly against the LDAP server from [forumsys](https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/) - I think the CI volume will not be too harsh on that site.

On the other hand, if and when that server goes offline, frab CI will break.

So I'm not sure if it makes sense to merge this or not.

An alternative way to test LDAP in CI is [here](https://cweiske.de/tagebuch/ldap-server-travis.htm); but it seem to carry a bunch of complications with it. i.e., the test would be different for CI than what you would run on your dev station; and there's an elaborated bring-up sequence.