### PR TITLE
Add exporter for all events in the verbose style of export_accepted

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -32,6 +32,15 @@ class EventsController < BaseConferenceController
     end
   end
 
+  def export_all
+    authorize @conference, :manage?
+    @events = @conference.events.all
+
+    respond_to do |format|
+      format.json { render :export }
+    end
+  end
+
   # current_users events
   def my
     authorize @conference, :read?

--- a/app/views/events/export.json.jbuilder
+++ b/app/views/events/export.json.jbuilder
@@ -1,12 +1,14 @@
 json.array! @events do |e|
   json.event_id e.id
-  json.extract! e, :track_id, :room_id, :start_time, :title, :abstract, :language
+  json.extract! e, :id, :track_id, :room_id, :start_time, :title, :subtitle, :description, :abstract, :language
   json.track_name e.track.try(:name)
   json.room_name e.room.try(:name)
   json.duration e.duration_in_minutes
   json.speaker_names e.speakers.map(&:public_name).join(', ')
   json.event_url event_url(e)
+  json.type e.event_type
   json.speakers e.speakers do |speaker|
+    json.id speaker.id
     json.public_name speaker.public_name
     json.abstract speaker.abstract
     json.description speaker.description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
           get :feedbacks
           get :start_review
           get :cards
+          get :export_all
           get :export_accepted
           get :export_confirmed
         end


### PR DESCRIPTION
I want to build an external tool that warns about speakers tweaking their availabilities to force content curators into putting them at prime time slots. This needs to happen even before lectures are accepted, confirmed or public.

That's where I need a view on all events for a robot user that includes all speakers and their avails, which already exists for the export_confirmed view.

This PR adds the same renderer for the export_all route.