### PR TITLE
UI improvements for scheduler

### DIFF
--- a/app/assets/images/external_link.svg
+++ b/app/assets/images/external_link.svg
@@ -1,0 +1,13 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 82 81" version="1.1" x="0px" y="0px">
+    <title>External Link</title>
+    <desc>source: https://thenounproject.com/term/external-link/594418/</desc>
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(0.000000, -17.000000)">
+            <path d="M65.0787075,33.0882353 L33.4558824,64.3382354" stroke="#000000" stroke-width="15" stroke-linecap="square"></path>
+            <polygon fill="#000000" transform="translate(72.134903, 29.456845) rotate(53.000000) translate(-72.134903, -29.456845) " points="68.5556866 14.7245467 97.9172862 36.850099 46.3525203 44.1891435"></polygon>
+            <polygon fill="#000000" points="48.5294118 28.6764706 0 28.6764706 0 97.7941176 69.1176471 97.7941176 69.1176471 50 58.0882353 61.0294118 58.0882353 86.7647059 11.0294118 86.7647059 11.0294118 39.7058824 37.5 39.7058824"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/assets/javascripts/schedule.js.coffee
+++ b/app/assets/javascripts/schedule.js.coffee
@@ -120,8 +120,8 @@ $ ->
     td = $(this)
     $("#add-event-modal #current-time").html(td.data("time"))
     $("ul#unscheduled-events").undelegate("click")
-    $("ul#unscheduled-events").delegate("li a", "click", (click_event) ->
-      li = $(this).parent()
+    $("ul#unscheduled-events").delegate("li span#add a", "click", (click_event) ->
+      li = $(this).parent().parent()
       new_event = $("<div></div>")
       new_event.html(li.children().first().html())
       new_event.addClass("event")

--- a/app/assets/javascripts/schedule.js.coffee
+++ b/app/assets/javascripts/schedule.js.coffee
@@ -6,10 +6,10 @@ update_event_position = (event) ->
   $(event).css("top", td.offset().top)
   return
 
-update_unscheduled_events = (track_id = "") ->
+update_unscheduled_events = () ->
   $.ajax(
-    url: $("form#update-track").attr("action"),
-    data: {track_id: track_id},
+    url: $("form#update-filters").attr("action"),
+    data: { track_id: $("select#track_select").val(), event_type: $("select#event_type_select").val() },
     dataType: "html",
     success: (data) ->
       $("ul#unscheduled-events").html(data)
@@ -97,7 +97,12 @@ $ ->
 
   # Track filter
   $("select#track_select").change ->
-    update_unscheduled_events($(this).val())
+    update_unscheduled_events()
+    true
+
+  # Event type filter
+  $("select#event_type_select").change ->
+    update_unscheduled_events()
     true
 
   for timeslot in $("table.room td")

--- a/app/assets/javascripts/schedule.js.coffee.erb
+++ b/app/assets/javascripts/schedule.js.coffee.erb
@@ -45,6 +45,11 @@ $ ->
   $("body").delegate("div.event", "mouseenter", ->
     event_div = $(this)
     return if event_div.find("a.close").length > 0
+    show_button = $("<a href='"+event_div.data("show-event-url")+"' target=_blank><img src='<%= asset_path("external_link.svg") %>' style='height:0.8rem;'></a>")
+    show_button.addClass("close").addClass("small")
+    event_div.prepend(show_button)
+    show_button.click (click_event) -> window.open(event_div.data("show-event-url"))
+    
     unschedule = $("<a href='#'>×</a>")
     unschedule.addClass("close").addClass("small")
     event_div.prepend(unschedule)
@@ -128,6 +133,7 @@ $ ->
       new_event.attr("id", li.attr("id"))
       new_event.css("height", li.data("height"))
       new_event.data("update-url", li.data("update-url"))
+      new_event.data("show-event-url", li.data("show-event-url"))
       $("#event-pane").append(new_event)
       add_event_to_slot(new_event, td)
       make_draggable(new_event)

--- a/app/assets/javascripts/schedule.js.coffee.erb
+++ b/app/assets/javascripts/schedule.js.coffee.erb
@@ -36,7 +36,7 @@ add_event_to_slot = (event, td, update = true) ->
         return
     )
   return
-
+  
 make_draggable = (element) ->
   element.draggable(revert: "invalid", opacity: 0.4, cursorAt: {left: 5, top: 5})
   true
@@ -78,6 +78,9 @@ $ ->
     click_event.preventDefault()
     false
   )
+  $("#add-event-modal").draggable({
+    handle: ".modal-header"
+  }); 
 
   # Buttons
   for button in $("a.toggle-room")
@@ -112,6 +115,7 @@ $ ->
 
   for timeslot in $("table.room td")
     $(timeslot).droppable(
+      accept: ".event",
       hoverClass: "event-hover",
       tolerance: "pointer",
       drop: (event, ui) ->

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,5 +1,5 @@
 class ScheduleController < BaseConferenceController
-  before_action :crew_only!, except: %i[update_track update_event]
+  before_action :crew_only!, except: %i[update_filters update_event]
 
   def index
     params[:day] ||= 0
@@ -10,13 +10,16 @@ class ScheduleController < BaseConferenceController
     @unscheduled_events = @conference.events.accepted.includes([:track, :room, :conflicts]).unscheduled.order(:title)
   end
 
-  def update_track
+  def update_filters
     authorize @conference, :manage?
     @unscheduled_events = if params[:track_id] and params[:track_id] =~ /\d+/
                             @conference.events.accepted.unscheduled.where(track_id: params[:track_id])
                           else
                             @conference.events.accepted.unscheduled
                           end
+    if params[:event_type].presence
+      @unscheduled_events = @unscheduled_events.where(event_type: params[:event_type])
+    end
     render partial: 'unscheduled_events'
   end
 

--- a/app/views/schedule/_event.html.haml
+++ b/app/views/schedule/_event.html.haml
@@ -1,6 +1,7 @@
 .event{ id: "event_#{event.id}",
         style: "height: #{event.time_slots * 20 - 7}px;",
         class: event.conflict_level,
+        :"data-show-event-url" => event_path(id: event.id),
         :"data-update-url" => schedule_update_event_path(id: event.id),
         :"data-room" => event.room&.name&.downcase,
         :"data-time" => event.start_time&.to_s(:rfc822) }

--- a/app/views/schedule/_unscheduled_events.html.haml
+++ b/app/views/schedule/_unscheduled_events.html.haml
@@ -2,4 +2,8 @@
   %li.unscheduled-event{ id: "event_#{event.id}",
           :"data-update-url" => schedule_update_event_path(id: event.id),
           :"data-height" => (event.time_slots * 20 - 7) }
-    = link_to event.title, "#"
+    %span{id: 'add'}
+      = link_to event.title, "#"
+    %span{id: 'show'}
+      = link_to image_tag('external_link.svg', style: 'height:0.8rem;', alt: '[show]'), event, target: '_blank'
+

--- a/app/views/schedule/_unscheduled_events.html.haml
+++ b/app/views/schedule/_unscheduled_events.html.haml
@@ -1,6 +1,7 @@
 - @unscheduled_events.each do |event|
   %li.unscheduled-event{ id: "event_#{event.id}",
           :"data-update-url" => schedule_update_event_path(id: event.id),
+          :"data-show-event-url" => event_path(id: event.id),
           :"data-height" => (event.time_slots * 20 - 7) }
     %span{id: 'add'}
       = link_to event.title, "#"

--- a/app/views/shared/_event_scheduler.html.haml
+++ b/app/views/shared/_event_scheduler.html.haml
@@ -54,9 +54,13 @@
             %span#current-time &nbsp;
         .modal-body
           %p
-            = form_tag schedule_update_track_path, id: "update-track" do
-              = label_tag "track_select", t('events_module.track_select')
-              = select_tag "track_select", content_tag(:option, t('all'), selected: true) + options_from_collection_for_select(@conference.tracks, :id, :name)
+            = form_tag schedule_update_filters_path, id: "update-filters" do
+              %p
+                = label_tag "track_select", t('events_module.track_select')
+                = select_tag "track_select", content_tag(:option, t('all'), selected: true) + options_from_collection_for_select(@conference.tracks, :id, :name)
+              %p
+                = label_tag "event_type_select", t('events_module.event_type_select')
+                = select_tag "event_type_select", options_from_collection_for_select(translated_options(@conference.events.group(:event_type).pluck(:event_type)), :last, :first), include_blank: t('all')
           %p
             %ul#unscheduled-events
               = render 'unscheduled_events'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -985,6 +985,7 @@ de:
     event_details: Event-Details
     event_feedbacks: Event-Feedbacks
     event_ratings: Event-Bewertungen der Reviewer
+    event_type_select: Nach Ereignistyp filtern
     events_by_gender: Events nach Geschlecht
     events_by_language: Events nach Sprache
     events_by_state: Events nach Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1037,6 +1037,7 @@ en:
     reject_event_no_email_hint: Reject this event without sending an automated email.
     toggle_description: Toggle Description >>
     track_select: filter by track
+    event_type_select: filter by event type
   expenses: Expenses
   expenses_module:
     error_person_have_no_expense: "%{person} does not currently have any expenses."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1025,6 +1025,7 @@ es:
     event_details: Detalles del evento
     event_feedbacks: Comentarios del evento
     event_ratings: Calificaciones del evento
+    event_type_select: filtrar por tipo de evento
     events_by_gender: Eventos por género
     events_by_language: Eventos por idioma
     events_by_state: Eventos por estado

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1006,6 +1006,7 @@ fr:
     event_details: Détails de l’évènement
     event_feedbacks: Retours sur les évènements
     event_ratings: Notes de l’évènement
+    event_type_select: filtrer par type d'événement
     events_by_gender: Évènements par genre
     events_by_language: Évènements par langue
     events_by_state: Évènements par etat

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1010,6 +1010,7 @@ it:
     event_details: Dettagli dell'evento
     event_feedbacks: Resi sugli eventi
     event_ratings: Note dell'evento
+    event_type_select: filtra per tipo di evento
     events_by_gender: Eventi per genere
     events_by_language: Eventi per lingua
     events_by_state: Eventi per stato

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -993,6 +993,7 @@ pt-BR:
     event_details: Detalhes do evento
     event_feedbacks: Feedback de Eventos
     event_ratings: Classificações do evento
+    event_type_select: filtrar por tipo de evento
     events_by_gender: Eventos por gênero
     events_by_language: Eventos por idioma
     events_by_state: Eventos por estado

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -983,6 +983,7 @@ ru:
     event_details: Сведения о мероприятии
     event_feedbacks: Отзывы о событиях
     event_ratings: Рейтинг событий
+    event_type_select: фильтр по типу события
     events_by_gender: События по полу
     events_by_language: События по языку
     events_by_state: События по штатам

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -983,6 +983,7 @@ zh:
     event_details: 活动详情
     event_feedbacks: 事件反馈
     event_ratings: 事件评级
+    event_type_select: 按事件类型过滤
     events_by_gender: 性别事件
     events_by_language: 语言事件
     events_by_state: 国家事件

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
         get '/events/join(/:token)' => 'events#join', as: :events_join
         post '/events/join/:token' => 'events#join'
         get '/schedule' => 'schedule#index', as: 'schedule'
-        get '/schedule/update_track' => 'schedule#update_track', as: 'schedule_update_track'
+        get '/schedule/update_filters' => 'schedule#update_filters', as: 'schedule_update_filters'
         put '/schedule/update_event' => 'schedule#update_event', as: 'schedule_update_event'
         resources :events do
           member do
@@ -75,7 +75,7 @@ Rails.application.routes.draw do
       get '/recent_changes' => 'recent_changes#index', as: 'recent_changes'
       post '/schedule.pdf' => 'schedule#custom_pdf', as: 'schedule_custom_pdf', defaults: { format: :pdf }
       get '/schedule' => 'schedule#index', as: 'schedule'
-      get '/schedule/update_track' => 'schedule#update_track', as: 'schedule_update_track'
+      get '/schedule/update_filters' => 'schedule#update_filters', as: 'schedule_update_filters'
       put '/schedule/update_event' => 'schedule#update_event', as: 'schedule_update_event'
       get '/schedule/new_pdf' => 'schedule#new_pdf', as: 'new_schedule_pdf'
       get '/schedule/html_exports' => 'schedule#html_exports'

--- a/test/controllers/schedule_controller_test.rb
+++ b/test/controllers/schedule_controller_test.rb
@@ -11,8 +11,8 @@ class ScheduleControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test 'should get update_track' do
-    get :update_track, params: { conference_acronym: @conference.acronym }
+  test 'should get update_filters' do
+    get :update_filters, params: { conference_acronym: @conference.acronym }
     assert_response :success
   end
 


### PR DESCRIPTION
This PR offers several improvements to the scheduler .

1. Ability to filter unscheduled tasks (the list you get when clicking a free slot on the schedule) according to event type, not only tracks. (This is compatible with https://github.com/frab/frab/pull/530)

2. Add the capability to open the event in a new browser window/tab, to get access to the tech rider etc. An "external_link" icon is added to scheduled events (when hovering) and no unscheduled events.

3. Make the modal window movable

4. Fix a bug where, when unscheduling an event, it would be appended to list presented, even if it does not match the filters presented.


![image](https://user-images.githubusercontent.com/20379005/67282811-2eb2dd80-f4db-11e9-95ad-09950075700c.png)


![image](https://user-images.githubusercontent.com/20379005/67357727-d6292200-f566-11e9-8797-785331c3284f.png)
