### PR TITLE
translate 'add event' modal header

### DIFF
--- a/app/views/shared/_event_scheduler.html.haml
+++ b/app/views/shared/_event_scheduler.html.haml
@@ -49,9 +49,7 @@
       #add-event-modal.modal{style: "display: none;"}
         .modal-header
           = link_to "×", "#", class: "close"
-          %h3
-            Add event at
-            %span#current-time &nbsp;
+          %h3=t('events_module.add_event_at', time: content_tag(:span, '', id: 'current-time')).html_safe
         .modal-body
           %p
             = form_tag schedule_update_filters_path, id: "update-filters" do

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -960,6 +960,7 @@ de:
     accept_event_no_email: Event accepten (ohne E-Mail)
     accept_event_no_email_hint: Setzt den Status des Events auf accepted, ohne eine automatisierte E-Mail zu senden.
     add_event: Event hinzufügen
+    add_event_at: Event bei %{time} hinzufügen
     add_event_hint: Fügen Sie ein neues Event hinzu.
     add_ticket: Ticket hinzufügen
     add_ticket_hint: Erstellen Sie ein Ticket für dieses Ereignis.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -947,6 +947,7 @@ en:
     accept_event_no_email: Accept event (no email)
     accept_event_no_email_hint: Accept this event without sending an automated email.
     add_event: Add event
+    add_event_at: Add event at %{time}
     add_event_hint: Add a new event.
     add_ticket: Add Ticket
     add_ticket_hint: Create a ticket for this event.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -974,6 +974,7 @@ fr:
     accept_event_no_email: Accepter l’évènement (pas de courriel)
     accept_event_no_email_hint: Accepte cet évènement sans envoyer de courriel.
     add_event: Nouvel évènement
+    add_event_at: Ajouter un événement à %{time}
     add_event_hint: Créé un nouvel évènement.
     add_ticket: Ajouter un ticket
     add_ticket_hint: Créé un ticket pour cet évènement.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -978,6 +978,7 @@ it:
     accept_event_no_email: Accetta l'evento (nessuna email)
     accept_event_no_email_hint: Accetta questo evento senza inviare un'e-mail.
     add_event: Nuovo evento
+    add_event_at: Aggiungi evento su %{time}
     add_event_hint: Crea un nuovo evento.
     add_ticket: Aggiungi un biglietto
     add_ticket_hint: Crea un ticket per questo evento.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -963,6 +963,7 @@ pt-BR:
     accept_event_no_email: Aceitar evento (sem email)
     accept_event_no_email_hint: Aceite este evento sem enviar um email automático.
     add_event: Adicionar Evento
+    add_event_at: Adicionar evento em %{time}
     add_event_hint: Adicione um novo evento.
     add_ticket: Adicionar ticket
     add_ticket_hint: Crie um ticket para este evento.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -953,6 +953,7 @@ ru:
     accept_event_no_email: Принять событие (нет электронной почты)
     accept_event_no_email_hint: Примите это событие, не отправляя автоматическое письмо.
     add_event: Добавить событие
+    add_event_at: Добавить событие на %{time}
     add_event_hint: Добавьте новое событие.
     add_ticket: Добавить билет
     add_ticket_hint: Создайте билет для этого мероприятия.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -953,6 +953,7 @@ zh:
     accept_event_no_email: 接受事件(无电子邮件)
     accept_event_no_email_hint: 接受此事件而不发送自动电子邮件。
     add_event: 添加活动
+    add_event_at: 在%{time}添加事件
     add_event_hint: 添加一个新事件。
     add_ticket: 添加票据
     add_ticket_hint: 为此活动创建一张票。


### PR DESCRIPTION
Change the header of the "add event" modal window in the scheduled to be translated.

![image](https://user-images.githubusercontent.com/20379005/67602952-6a220600-f780-11e9-8b64-2b97d1ac4cd7.png)

![image](https://user-images.githubusercontent.com/20379005/67602966-70b07d80-f780-11e9-9bd5-46f60ddca8f5.png)
![image](https://user-images.githubusercontent.com/20379005/67603006-82922080-f780-11e9-80c1-1912c606f414.png)
