### PR TITLE
change timepicker resolution to minutes

### DIFF
--- a/app/views/conferences/_day_fields.html.haml
+++ b/app/views/conferences/_day_fields.html.haml
@@ -9,7 +9,7 @@
   $(function() {
     $('div.datetime input').datetimepicker({
       dateFormat: "yy-mm-dd",
-      timeFormat: "HH:mm:ss",
+      timeFormat: "HH:mm",
       separator: "T",
       stepHour: 1,
       stepMinute: #{@conference.timeslot_duration}


### PR DESCRIPTION
This PR aims to remove the **seconds** control from the date time picker at the Settings -> Days configuration page.

The seconds control was added by @ShadowBan in https://github.com/frab/frab/commit/66c4a3cc826073c9ec5b1d4af317934329433622 - perhaps by mistake?

== Current ==

![image](https://user-images.githubusercontent.com/20379005/67800246-a199f680-fa8f-11e9-99da-ee32fe7734ce.png)

== After applying this PR ==

![image](https://user-images.githubusercontent.com/20379005/67800276-ab235e80-fa8f-11e9-937c-94dfeb44588f.png)


h1. 