### PR TITLE
Fix day model validations for when end_date or start_date attributes are nil

### DIFF
--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -17,13 +17,14 @@ class Day < ApplicationRecord
   validate :does_not_overlap
 
   def start_date_before_end_date
+    return if start_date.nil? || end_date.nil?
     errors.add(:end_date, 'should be after start date') if start_date >= end_date
   end
 
   def does_not_overlap
-    return if conference.nil?
+    return if [conference, start_date, end_date].include?(nil)
     conference.days.each { |day|
-      next if day == self
+      next if day == self || day.start_date.nil? || day.end_date.nil?
       errors.add(:start_date, "day overlapping with day #{day.label} from this conference") if start_date.between?(day.start_date, day.end_date)
       errors.add(:end_date, "day overlapping with day #{day.label} from this conference") if end_date.between?(day.start_date, day.end_date)
     }

--- a/test/models/day_test.rb
+++ b/test/models/day_test.rb
@@ -25,6 +25,15 @@ class DayTest < ActiveSupport::TestCase
     assert_equal false, conference.days[1].valid?
   end
 
+  test 'end date is nil' do
+    day = create(:day)
+    assert_equal true, day.valid?
+
+    day.end_date = nil
+    assert_equal false, day.valid?
+    assert day.errors.added?  :end_date, :blank
+  end
+
   test 'updating day updates conference' do
     conference = create(:three_day_conference)
     conference.reload


### PR DESCRIPTION
Model validations are always all run, therefore custom validations which rely on the start and end date not being nil were failing and raising an error

Before: 
![image](https://user-images.githubusercontent.com/2881483/68063154-bb913e80-fd06-11e9-8e0f-2ec9f1cdd8eb.png)


After: 
![image](https://user-images.githubusercontent.com/2881483/68063142-a61c1480-fd06-11e9-966c-c945a921b377.png)
