### PR TITLE
report failure to add mail template

### DIFF
--- a/app/controllers/mail_templates_controller.rb
+++ b/app/controllers/mail_templates_controller.rb
@@ -54,8 +54,11 @@ class MailTemplatesController < BaseConferenceController
 
   def create
     t = MailTemplate.new(mail_template_params)
-    @conference.mail_templates << t
-    redirect_to(mail_templates_path, notice: t('emails_module.notice_template_added'))
+    if @conference.mail_templates << t
+      redirect_to(mail_templates_path, notice: t('emails_module.notice_template_added'))
+    else
+      redirect_to(mail_templates_path, alert: t('emails_module.error_template_add_failed'))
+    end
   end
 
   def destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -868,6 +868,7 @@ en:
     error_missing_speaker_email: 'Cannot send mails: Not all speakers have email addresses.'
     error_state_update: Cannot update state.
     error_state_update_ex: 'Cannot update state: %{ex}.'
+    error_template_add_failed: Mail template creation failed.
     error_unnotifiable_state: Event not in a notifiable state.
     filters:
       all_speakers_in_confirmed_events: All speakers involved in all confirmed events

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -922,6 +922,7 @@ es:
     error_missing_speaker_email: 'No se pueden enviar correos: no todos los oradores tienen direcciones de correo electrónico.'
     error_state_update: No se puede actualizar el estado.
     error_state_update_ex: 'No se puede actualizar el estado: %{ex}.'
+    error_template_add_failed: La creación de la plantilla de correo falló.
     error_unnotifiable_state: Evento no en un estado de notificación.
     filters:
       all_speakers_in_confirmed_events: Todos los oradores involucrados en todos los eventos confirmados

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -895,6 +895,7 @@ fr:
     error_missing_speaker_email: 'Impossible d’envoyer des courriels : les orateurs n’ont pas tous d’adresse de courriel.'
     error_state_update: Impossible de mettre à jour l’état.
     error_state_update_ex: 'Impossible de mettre à jour l’état : %{ex}.'
+    error_template_add_failed: La création du modèle de courrier a échoué.
     error_unnotifiable_state: L’évènement n’est pas dans un état notifiable.
     filters:
       all_speakers_in_confirmed_events: Tous les orateurs dans tous les évènements confirmés

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -899,6 +899,7 @@ it:
     error_missing_speaker_email: 'Le e-mail non possono essere inviate: non tutti gli oratori hanno un indirizzo e-mail.'
     error_state_update: Impossibile aggiornare lo stato.
     error_state_update_ex: 'Impossibile aggiornare lo stato: %{ex}.'
+    error_template_add_failed: Creazione del modello di posta non riuscita.
     error_unnotifiable_state: L'evento non è in uno stato di notifica.
     filters:
       all_speakers_in_confirmed_events: Tutti i relatori in tutti gli eventi confermati

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -890,6 +890,7 @@ pt-BR:
     error_missing_speaker_email: 'Não é possível enviar e-mails: nem todos os palestrantes têm endereços de e-mail.'
     error_state_update: Não é possível atualizar o estado.
     error_state_update_ex: 'Não é possível atualizar o estado: %{ex}.'
+    error_template_add_failed: Falha na criação do modelo de email.
     error_unnotifiable_state: Evento não em um estado notificável.
     filters:
       all_speakers_in_confirmed_events: Todos os palestrantes envolvidos em todos os eventos confirmados

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -874,6 +874,7 @@ ru:
     error_missing_speaker_email: Невозможно отправить почту. Не все колонки имеют адреса электронной почты.
     error_state_update: Не удалось обновить состояние.
     error_state_update_ex: 'Не удалось обновить состояние: %{ex}.'
+    error_template_add_failed: Не удалось создать почтовый шаблон.
     error_unnotifiable_state: Событие не в уведомляемом состоянии.
     filters:
       all_speakers_in_confirmed_events: Все ораторы, участвующие во всех подтвержденных событиях

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -874,6 +874,7 @@ zh:
     error_missing_speaker_email: 无法发送邮件：并非所有发言者都有电子邮件地址。
     error_state_update: 无法更新状态。
     error_state_update_ex: 无法更新状态：%{ex}。
+    error_template_add_failed: 邮件模板创建失败。
     error_unnotifiable_state: 事件不在通知状态。
     filters:
       all_speakers_in_confirmed_events: 所有发言人都参与了所有确认的事件


### PR DESCRIPTION
Click Mail Templates --> Add mail template and click "Create Mail Template" without filling any of the text fields.

Response with current code: `Mail template was successfully added.`

Response after this PR is applied: `Mail template creation failed.`

