### PR TITLE
highlight late submissions

### DIFF
--- a/app/assets/stylesheets/frab.css
+++ b/app/assets/stylesheets/frab.css
@@ -249,3 +249,22 @@ ul.event_classifiers_checkboxes input[type=checkbox] {
 .help-block {
     width: 430px;
 }
+span.event-tag {
+    display: inline;
+    min-width: 200px;
+    color: black;
+    padding: 2px 4px 2px 4px;
+    border: thin;
+    border-color: black;
+    border-style: solid;
+    vertical-align: middle;
+}
+span.event-tag.small {
+    font-size: 8px; 
+}
+span.after-deadline.soft {
+    background-color: orange;
+}
+span.after-deadline.hard {
+    background-color: red;
+}

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -190,6 +190,25 @@ class Event < ApplicationRecord
     self.tech_rider = ''
     self
   end
+  
+  def date_of_submission_in_conference_tz
+    created_at.in_time_zone(conference.timezone).to_date
+  end
+  
+  def submitted_after_soft_deadline?
+    return true if submitted_after_hard_deadline?
+    return false unless conference.call_for_participation
+    return true if date_of_submission_in_conference_tz > conference.call_for_participation&.end_date
+    false
+  end
+
+  def submitted_after_hard_deadline?
+    return false unless conference.call_for_participation&.hard_deadline
+    return true if date_of_submission_in_conference_tz > conference.call_for_participation&.hard_deadline
+    return false
+  end
+  
+  
 
   private
 

--- a/app/views/events/_event_tags.html.haml
+++ b/app/views/events/_event_tags.html.haml
@@ -1,0 +1,7 @@
+- scope = ('events_module.indicator.short' if short) || 'events_module.indicator.full'
+- if event.submitted_after_hard_deadline?
+  %span{class: [short && 'small', 'event-tag', 'after-deadline', 'hard']}= t('submitted_after_soft_deadline', scope: scope)
+- elsif event.submitted_after_soft_deadline?
+  %span{class: [short && 'small', 'event-tag', 'after-deadline', 'soft']}= t('submitted_after_hard_deadline', scope: scope)
+
+

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -42,7 +42,9 @@
         %td= link_to_unless params[:event_type].present?, event.event_type, request.query_parameters.merge(:event_type => event.event_type)
         - if policy(@conference).manage?
           %td= link_to_unless params[:event_state].present?, event.state, request.query_parameters.merge(:event_state => event.state)
-        %td= l(event.created_at.to_date)
+        %td
+          %span.nowrap= l(event.date_of_submission_in_conference_tz)
+          = render partial: 'events/event_tags', locals: { event: event, short: true }
         %td.buttons
           = action_button "small", t('show'), event
           - if policy(@conference).manage?

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -21,7 +21,7 @@
           = action_button "", t('events_module.custom_notification'), custom_notification_event_path(event_id: @event), method: :post, hint: t('events_module.custom_notification_hint')
         - if @conference.ticket_server_enabled?
           - unless @event.remote_ticket?
-            = action_button "primary", t('events_module.add_ticket') , create_event_ticket_path(event_id: @event), method: :post, title: t('events_module.add_ticket_hint')
+            = action_button "primary", t('events_module.add_ticket'), create_event_ticket_path(event_id: @event), method: :post, title: t('events_module.add_ticket_hint')
       - elsif current_user.is_speaker_in?(@event)
         = action_button "small", t('edit'), edit_cfp_event_path(@event)
 
@@ -134,3 +134,6 @@
       %p
         %b= Event.human_attribute_name(:tech_rider) + ':'
         = @event.tech_rider
+  .row
+    .span16
+      = render partial: 'events/event_tags', locals: { event: @event, short: false }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1010,6 +1010,13 @@ de:
     events_in_other_conferences: Events in anderen Konferenzen
     feedback_not_enabled: Das Feedback-System ist nicht aktiviert.
     hide_all: Alles verbergen
+    indicator:
+      full:
+        submitted_after_hard_deadline: Eingereicht nach harter Frist
+        submitted_after_soft_deadline: Eingereicht nach Fristablauf
+      short:
+        submitted_after_hard_deadline: Spät
+        submitted_after_soft_deadline: SPÄT
     inputs:
       hints:
         do_not_record: Soll dieses Event aufgezeichnet werden?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1003,6 +1003,13 @@ en:
     events_in_other_conferences: Events in other conferences
     feedback_not_enabled: The feedback system is not enabled.
     hide_all: hide all
+    indicator:
+      full:
+        submitted_after_hard_deadline: Submitted after hard deadline
+        submitted_after_soft_deadline: Submitted after deadline
+      short:
+        submitted_after_hard_deadline: Late
+        submitted_after_soft_deadline: LATE
     inputs:
       hints:
         do_not_record: Will this event be recorded?

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1051,6 +1051,13 @@ es:
     events_in_other_conferences: Eventos en otras conferencias
     feedback_not_enabled: El sistema de retroalimentación no está habilitado.
     hide_all: ocultar todo
+    indicator:
+      full:
+        submitted_after_hard_deadline: Enviado después de la fecha límite
+        submitted_after_soft_deadline: Enviado después de la fecha límite
+      short:
+        submitted_after_hard_deadline: Tarde
+        submitted_after_soft_deadline: TARDE
     inputs:
       hints:
         do_not_record: "¿Se grabará este evento?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1032,6 +1032,13 @@ fr:
     events_in_other_conferences: Évènements dans d’autres conférences
     feedback_not_enabled: Le système de retours n’est pas activé.
     hide_all: Tout cacher
+    indicator:
+      full:
+        submitted_after_hard_deadline: Soumis après la date limite
+        submitted_after_soft_deadline: Soumis après la date limite
+      short:
+        submitted_after_hard_deadline: En retard
+        submitted_after_soft_deadline: EN RETARD
     inputs:
       hints:
         do_not_record: Est-ce que l’évènement sera enregistré ?

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1036,6 +1036,13 @@ it:
     events_in_other_conferences: Eventi in altre conferenze
     feedback_not_enabled: Il sistema di restituzione non è attivato.
     hide_all: Nascondi tutto
+    indicator:
+      full:
+        submitted_after_hard_deadline: Presentato dopo una scadenza rigida
+        submitted_after_soft_deadline: Presentato dopo la scadenza
+      short:
+        submitted_after_hard_deadline: in ritardo
+        submitted_after_soft_deadline: LATE
     inputs:
       hints:
         do_not_record: L'evento sarà salvato?

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1019,6 +1019,13 @@ pt-BR:
     events_in_other_conferences: Eventos em outras conferências
     feedback_not_enabled: O sistema de feedback não está ativado.
     hide_all: esconda tudo
+    indicator:
+      full:
+        submitted_after_hard_deadline: Enviado após prazo final
+        submitted_after_soft_deadline: Enviado após o prazo
+      short:
+        submitted_after_hard_deadline: Atrasado
+        submitted_after_soft_deadline: ATRASADO
     inputs:
       hints:
         do_not_record: Este evento será gravado?

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1009,6 +1009,13 @@ ru:
     events_in_other_conferences: События на других конференциях
     feedback_not_enabled: Система обратной связи не включена.
     hide_all: скрыть все
+    indicator:
+      full:
+        submitted_after_hard_deadline: Представлено после жесткого срока
+        submitted_after_soft_deadline: Представлено после крайнего срока
+      short:
+        submitted_after_hard_deadline: поздно
+        submitted_after_soft_deadline: ПОЗЖЕ
     inputs:
       hints:
         do_not_record: Будет ли это событие записано?

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1009,6 +1009,13 @@ zh:
     events_in_other_conferences: 其他会议中的活动
     feedback_not_enabled: 反馈系统未启用。
     hide_all: 全部藏起来
+    indicator:
+      full:
+        submitted_after_hard_deadline: 在艰难的截止日期之后提交
+        submitted_after_soft_deadline: 截止日期后提交
+      short:
+        submitted_after_hard_deadline: 晚的
+        submitted_after_soft_deadline: 晚的
     inputs:
       hints:
         do_not_record: 这个事件会被记录吗？


### PR DESCRIPTION
1. Add ORANGE tag if event was submitted after cfp end; or RED tag if submitted after hard deadline. The tag appears in event lists in a short form, and in an explicit form in the event details page.

2. Change creation date display to conference timezone.

see #490

![image](https://user-images.githubusercontent.com/20379005/68076771-b04f1900-fdc1-11e9-9328-dad924ab6da7.png)

![image](https://user-images.githubusercontent.com/20379005/68076772-b34a0980-fdc1-11e9-9646-fb4bbb235ccb.png)
