### PR TITLE
allow review metrics starting with digit

### DIFF
--- a/app/models/review_metric.rb
+++ b/app/models/review_metric.rb
@@ -12,7 +12,7 @@ class ReviewMetric < ApplicationRecord
   def safe_name
     # safe_name is used as an sql term, and also as a request parameter.
     # So we try to have it similiar to the review metric name.
-    name.parameterize.gsub(%r{[^a-z0-9]}, '_').presence || "rm#{id}"
+    name.parameterize.gsub(%r{[^a-z0-9]}, '_').gsub(%r{^(?=[0-9])}, '_').presence || "rm#{id}"
   end
 
   validates :name, presence: true, uniqueness: { scope: :conference }


### PR DESCRIPTION
Before this change, a review metric starting with a digit will
convert to an sql term starting with a digit, which is not
acceptable SQL.