### PR TITLE
Silence devise warnings in tests

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,21 +1,13 @@
-- content_for :title do
-  = link_to t('page_titles.resend_confirmation'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1
-      = t('titles.resend_confirmation_instructions')
-  .row
-    .span16
-
-      = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
-
-        = devise_error_messages!
-
-        %fieldset.inputs
-          = f.input :email, autofocus: true
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('resend')
-
+%h2 Resend confirmation instructions
+= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  = f.full_error :confirmation_token
+  .form-inputs
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+      input_html: { autocomplete: "email" }
+  .form-actions
+    = f.button :submit, "Resend confirmation instructions"
 = render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,6 +1,0 @@
-
-<%= t('devise.mailer.confirmation_instructions.headline', {email: @email}) %>
-
-<%= t('devise.mailer.confirmation_instructions.text') %>
-
-<%= confirmation_url(@resource, confirmation_token: @token) %>

--- a/app/views/devise/mailer/confirmation_instructions.text.haml
+++ b/app/views/devise/mailer/confirmation_instructions.text.haml
@@ -1,0 +1,3 @@
+= t('devise.mailer.confirmation_instructions.headline', {email: @email})
+= t('devise.mailer.confirmation_instructions.text')
+= confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/email_changed.text.erb
+++ b/app/views/devise/mailer/email_changed.text.erb
@@ -1,7 +1,0 @@
-<%= t('devise.mailer.email_change.headline', {email: @email}) %>
-
-<% if @resource.try(:unconfirmed_email?) %>
-<%= t('devise.mailer.email_change.text_being_changed', {email: @resource.unconfirmed_email}) %>
-<% else %>
-<%= t('devise.mailer.email_change.text_been_changed', {email: @resource.email}) %>
-<% end %>

--- a/app/views/devise/mailer/email_changed.text.haml
+++ b/app/views/devise/mailer/email_changed.text.haml
@@ -1,0 +1,5 @@
+= t('devise.mailer.email_change.headline', {email: @email})
+- if @resource.try(:unconfirmed_email?)
+  = t('devise.mailer.email_change.text_being_changed', {email: @resource.unconfirmed_email})
+- else
+  = t('devise.mailer.email_change.text_been_changed', {email: @resource.email})

--- a/app/views/devise/mailer/password_change.text.erb
+++ b/app/views/devise/mailer/password_change.text.erb
@@ -1,3 +1,0 @@
-<%= t('devise.mailer.password_change.headline', {email: @resource.email}) %>
-
-<%= t('devise.mailer.password_change.text') %>

--- a/app/views/devise/mailer/password_change.text.haml
+++ b/app/views/devise/mailer/password_change.text.haml
@@ -1,0 +1,2 @@
+= t('devise.mailer.password_change.headline', {email: @resource.email})
+= t('devise.mailer.password_change.text')

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,3 +1,0 @@
-<%= t('devise.mailer.password_change_instructions.headline', {email: @resource.email}) %>
-
-<%= t('devise.mailer.password_change_instructions.text', {link: edit_password_url(@resource, reset_password_token: @token)}) %>

--- a/app/views/devise/mailer/reset_password_instructions.text.haml
+++ b/app/views/devise/mailer/reset_password_instructions.text.haml
@@ -1,0 +1,2 @@
+= t('devise.mailer.password_change_instructions.headline', {email: @resource.email})
+= t('devise.mailer.password_change_instructions.text', {link: edit_password_url(@resource, reset_password_token: @token)})

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,3 +1,0 @@
-<%= t('devise.mailer.unlock_instructions.headline', {email: @resource.email}) %>
-
-<%= t('devise.mailer.unlock_instructions.text', {link: unlock_url(@resource, unlock_token: @token)}) %>

--- a/app/views/devise/mailer/unlock_instructions.text.haml
+++ b/app/views/devise/mailer/unlock_instructions.text.haml
@@ -1,0 +1,2 @@
+= t('devise.mailer.unlock_instructions.headline', {email: @resource.email})
+= t('devise.mailer.unlock_instructions.text', {link: unlock_url(@resource, unlock_token: @token)})

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,25 +1,19 @@
-- content_for :title do
-  = link_to t('page_titles.change_password'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1= t('titles.change_your_password')
-
-  .row
-    .span16
-      = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, defaults:{error: false}) do |f|
-
-        = devise_error_messages!
-
-        %fieldset.inputs
-          = f.hidden_field :reset_password_token
-          - if @minimum_password_length
-            = f.input :password, autocomplete: 'off', hint: t('inputs.hints.password_length', {length: @minimum_password_length})
-          - else
-            = f.input :password, autocomplete: 'off'
-
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('session.update_password')
-
+%h2 Change your password
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = f.error_notification
+  = f.input :reset_password_token, as: :hidden
+  = f.full_error :reset_password_token
+  .form-inputs
+    = f.input :password,
+      label: "New password",
+      required: true,
+      autofocus: true,
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      label: "Confirm your new password",
+      required: true,
+      input_html: { autocomplete: "new-password" }
+  .form-actions
+    = f.button :submit, "Change my password"
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,18 +1,11 @@
-- content_for :title do
-  = link_to t('page_titles.change_password'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1= t('titles.forgot_your_password')
-
-  .row
-    .span16
-      = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
-        = devise_error_messages!
-        %fieldset.inputs
-          = f.input :email
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('devise.resend_password_instructions')
-
+%h2 Forgot your password?
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
+  .form-actions
+    = f.button :submit, "Send me reset password instructions"
 = render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,33 +1,26 @@
--# TODO See if this view has to be. It comes from Devise, and there is a route to the action but I don't think it should be.
-- content_for :title do
-  = link_to t('page_titles.edit_account'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1= t('titles.edit_an_account', {name: resource_name.to_s.humanize})
-
-  .row
-    .span16
-      = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, defaults:{error: false}) do |f|
-        = devise_error_messages!
-
-        %fieldset.inputs
-          = f.input :email
-
-          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-            = t('devise.waiting_for_confirmation', {email: resource.unconfirmed_email})
-
-          - if @minimum_password_length
-            = f.input :password, autocomplete: 'off', hint: t('devise.leave_password_blank_hint') + ' - ' + t('inputs.hints.password_length', {length: @minimum_password_length})
-          - else
-            = f.input :password, autocomplete: 'off', hint: t('devise.leave_password_blank_hint')
-
-          = f.input :password_confirmation, autocomplete: 'off'
-          = f.input :current_password, autocomplete: 'off', hint: t('devise.current_password_hint')
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('devise.update_account')
-
-%h2= t('devise.cancel_account')
-= raw( t('devise.cancel_account_text', {link: button_to(t('devise.cancel_account'), registration_path(resource_name), data: { confirm: t('are_you_sure')}, method: :delete, class: "btn danger")}))
-= link_to t('navigation.back'), :back
+%h2
+  Edit #{resource_name.to_s.humanize}
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email, required: true, autofocus: true
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      %p
+        Currently waiting confirmation for: #{resource.unconfirmed_email}
+    = f.input :password,
+      hint: "leave it blank if you don't want to change it",
+      required: false,
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      required: false,
+      input_html: { autocomplete: "new-password" }
+    = f.input :current_password,
+      hint: "we need your current password to confirm your changes",
+      required: true,
+      input_html: { autocomplete: "current-password" }
+  .form-actions
+    = f.button :submit, "Update"
+%h3 Cancel my account
+%p
+  Unhappy? #{link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,28 +1,18 @@
-- content_for :title do
-  = link_to t('page_titles.signup'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1
-      = t('titles.session_signup')
-  .row
-    .span16
-
-      =simple_form_for(resource, as: resource_name, url: registration_path(resource_name), defaults:{error: false}) do |f|
-
-        = devise_error_messages!
-
-        %fieldset.inputs
-          = f.input :email
-
-          - if @minimum_password_length
-            = f.input :password, autocomplete: 'off', hint: t('inputs.hints.password_length', {length: @minimum_password_length})
-          - else
-            = f.input :password, autocomplete: 'off'
-
-          = f.input :password_confirmation, autocomplete: 'off'
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('session.signup')
-
-= render 'devise/shared/links'
+%h2 Sign up
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
+    = f.input :password,
+      required: true,
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      required: true,
+      input_html: { autocomplete: "new-password" }
+  .form-actions
+    = f.button :submit, "Sign up"
+= render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,24 +1,14 @@
--# Note that this view has been created from the Devise one.
--# Compared to the sessions/new.html.haml, it does not contain all the
--# links depending on context. Anyway, sessions/new.html.haml seems not to be used...
-- content_for :title do
-  = link_to t('page_titles.login'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1= t('titles.session_login')
-  - if devise_mapping.registerable?
-    .row
-      .span16
-    
-        = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-    
-          %fieldset.inputs
-            = f.input :email
-            = f.input :password
-            = f.input :remember_me, as: :inline_boolean if devise_mapping.rememberable?
-    
-          .actions
-          = f.button :submit, class: 'primary', value: t('session.login')
-
-= render 'devise/shared/links'
+%h2 Log in
+= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .form-inputs
+    = f.input :email,
+      required: false,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
+    = f.input :password,
+      required: false,
+      input_html: { autocomplete: "current-password" }
+    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+  .form-actions
+    = f.button :submit, "Log in"
+= render "devise/shared/links"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation
+    %h2
+      = I18n.t("errors.messages.not_saved",
+        count: resource.errors.count,
+        resource: resource.class.model_name.human.downcase)
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,30 +1,19 @@
 - if controller_name != 'sessions'
-  = link_to t('cfp.sign_in'), new_session_path(resource_name)
-  <br>
-
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to t('cfp.sign_up'), new_registration_path(resource_name)
-  <br>
-
+  = link_to "Sign up", new_registration_path(resource_name)
+  %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to t('cfp.forgot_password_button'), new_password_path(resource_name)
-  <br>
-
+  = link_to "Forgot your password?", new_password_path(resource_name)
+  %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
-  = link_to t('cfp.resend_confirmation_button'), new_confirmation_path(resource_name)
-  <br>
-
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
 - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
-  = link_to t('devise.links.no_unlock_instructions'), new_unlock_path(resource_name)
-  <br>
-
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
 - if devise_mapping.omniauthable?
   - resource_class.omniauth_providers.each do |provider|
-    = link_to t('devise.links.sign_in_with', 
-                {provider: ENV.fetch('NAME_FOR_'+provider.to_s.upcase,
-                                     t(provider, 
-                                       scope: 'devise.links', 
-                                       default: OmniAuth::Utils.camelize(provider)))}),
-              omniauth_authorize_path(resource_name, provider), 
-              method: :post
-    <br>
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,19 +1,12 @@
-- content_for :title do
-  = link_to t('page_titles.unlock_instructions'), root_url, class: 'brand'
-
-%section
-  .page-header
-    %h1= t('titles.unlock_instructions')
-
-  .row
-    .span16
-      = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
-        = devise_error_messages!
-
-        %fieldset.inputs
-          = f.input :email
-
-        .actions
-          = f.button :submit, class: 'primary', value: t('devise.resend_unlock_instructions')
-
+%h2 Resend unlock instructions
+= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  = f.full_error :unlock_token
+  .form-inputs
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
+  .form-actions
+    = f.button :submit, "Resend unlock instructions"
 = render "devise/shared/links"

--- a/test/features/submit_event_test.rb
+++ b/test/features/submit_event_test.rb
@@ -9,8 +9,8 @@ class SubmitEventTest < FeatureTest
   def sign_up_steps
     click_on 'Sign Up', match: :first
     fill_in 'Email', with: @user.email
-    fill_in 'Password', with: @user.password
-    fill_in 'Password confirmation', with: @user.password
+    fill_in 'user_password', with: @user.password
+    fill_in 'user_password_confirmation', with: @user.password
     click_on 'Sign up'
     assert_content page, 'A message with a confirmation link has been sent to your email address'
 


### PR DESCRIPTION
I got a lot of troubling warnings:

>  DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
> is deprecated and it will be removed in the next major version.
> To customize the errors styles please run `rails g devise:views` and modify the
> `devise/shared/error_messages` partial.
>  (called from block in _app_views_devise_registrations_new_html_haml__403213825357176102_17391016020 at /usr/home/erdgeist/frab/app/views/devise/registrations/new.html.haml:13)

and was told to `rails g devise:views`. Which I did. I then noticed there's a mixture of erb and haml templates lingering around, so I used the guide here https://github.com/plataformatec/devise/wiki/How-To:-Create-Haml-and-Slim-Views to consolidate all templates to haml.

Then I removed the html.haml templates for the mailer, to avoid multipart mails being sent.

One test called `sign_up_steps` had to be fixed, because it couldn't find the password field anymore. But now all tests work fine and without devise warnings.

Next up: Possibly removing unneeded templates.