### PR TITLE
fix event count

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -114,7 +114,7 @@ class EventsController < BaseConferenceController
     @events = result.paginate page: page_param
     clean_events_attributes
     
-    @num_of_matching_events = @events.count
+    @num_of_matching_events = result.pluck(:id).count
 
     # total ratings:
     @events_total = @conference.events.count


### PR DESCRIPTION
This PR fixes a bug. The events count (see #577) shown in the 'event ratings' page was counting post pagination instead of pre pagination.