### PR TITLE
Add substitution for eventid

### DIFF
--- a/app/models/event_person.rb
+++ b/app/models/event_person.rb
@@ -79,6 +79,7 @@ class EventPerson < ApplicationRecord
     locale = person.locale_for_mailing(event.conference)
     string = s.gsub '%{conference}', conference.title
     string.gsub! '%{event}', event.title
+    string.gsub! '%{event_id}', event.id
     string.gsub! '%{subtitle}', event.subtitle || ''
     string.gsub! '%{type}', event.localized_event_type(locale)
     string.gsub! '%{track}', event.track_name || ''

--- a/app/models/event_person.rb
+++ b/app/models/event_person.rb
@@ -79,7 +79,7 @@ class EventPerson < ApplicationRecord
     locale = person.locale_for_mailing(event.conference)
     string = s.gsub '%{conference}', conference.title
     string.gsub! '%{event}', event.title
-    string.gsub! '%{event_id}', event.id
+    string.gsub! '%{event_id}', event.id.to_s
     string.gsub! '%{subtitle}', event.subtitle || ''
     string.gsub! '%{type}', event.localized_event_type(locale)
     string.gsub! '%{track}', event.track_name || ''

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -20,6 +20,7 @@ class Notification < ApplicationRecord
     'forename'    => I18n.t('conferences_module.variables.forename'),
     'surname'     => I18n.t('conferences_module.variables.surname'),
     'event'       => I18n.t('conferences_module.variables.event'),
+    'event_id'    => I18n.t('conferences_module.variables.event_id'),
     'subtitle'    => I18n.t('conferences_module.variables.subtitle'),
     'type'        => I18n.t('conferences_module.variables.type'),
     'track'       => I18n.t('conferences_module.variables.track'),

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -560,8 +560,9 @@ de:
       conference: Konferenzname
       date: Datum des Events
       event: Name des Events
+      event_id: Eindeutige ID des Events
       forename: Vorname des Sprechers
-      joinlink: Link zur Teilnahme an der Veranstaltung
+      joinlink: Link zur Einladung eines Co-Sprechers
       link: Bestätigungslink
       public_name: Öffentlicher Name des Sprechers
       room: Raum des Events

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -551,6 +551,7 @@ en:
       conference: Conference name
       date: Date of presentation
       event: Event title
+      event_id: Internal event id
       forename: Speaker forename
       joinlink: Link for joining event
       link: Confirmation link


### PR DESCRIPTION
For last Congress, we prepared speaker-specific check lists that would link to their respective frab event pages. Those checklists were rendered per event.

But when sending out acceptance mails, there was no way to automatically link to the document, since the event-id could not be inserted.

This PR simply adds the event_id variable to the list of substitutable parameters.