### PR TITLE
Fix 642

### DIFF
--- a/app/lib/conference_scrubber.rb
+++ b/app/lib/conference_scrubber.rb
@@ -74,5 +74,6 @@ class ConferenceScrubber
     # keeps events average rating for performance reasons
     EventRating.skip_callback(:save, :after, :update_average)
     EventRating.joins(:event).where(Event.arel_table[:conference_id].eq(@conference.id)).destroy_all
+    EventRating.set_callback(:save, :after, :update_average)
   end
 end

--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -68,6 +68,8 @@ class ImportExportHelper
       unpack_paperclip_files
       restore_all_data
     end
+    
+    enable_callbacks
   end
 
   private
@@ -372,7 +374,15 @@ class ImportExportHelper
     EventRating.skip_callback(:save, :after, :update_average)
     EventFeedback.skip_callback(:save, :after, :update_average)
   end
-
+  
+  def enable_callbacks
+    EventPerson.set_callback(:save, :after, :update_speaker_count)
+    Event.set_callback(:save, :after, :update_conflicts)
+    Availability.set_callback(:save, :after, :update_event_conflicts)
+    EventRating.set_callback(:save, :after, :update_average)
+    EventFeedback.set_callback(:save, :after, :update_average)
+  end
+  
   def update_counters
     ActiveRecord::Base.connection.execute("UPDATE events SET speaker_count=(SELECT count(*) FROM event_people WHERE events.id=event_people.event_id AND event_people.event_role='speaker')")
     update_event_average('event_ratings', 'average_rating')

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -81,8 +81,8 @@ class Day < ApplicationRecord
 
   def update_conference_date
     return if conference.new_record? or conference.destroyed?
-    start_date = conference.days.pluck(:start_date).min
-    end_date = conference.days.pluck(:end_date).max
+    start_date = conference.days.minimum(:start_date)
+    end_date = conference.days.maximum(:end_date)
     conference.update(start_date: start_date, end_date: end_date)
     Conference.where(parent_id: conference.id).update_all(start_date: start_date, end_date: end_date)
   end

--- a/app/views/home/_table.html.haml
+++ b/app/views/home/_table.html.haml
@@ -11,9 +11,9 @@
           - if conference.logo.present?
             = image_box conference&.logo, :small
         %td
-          = l(conference.start_date.to_date)
+          = l(conference.start_date.to_date) unless conference.start_date.blank?
           \-
-          = l(conference.end_date.to_date)
+          = l(conference.end_date.to_date) unless conference.end_date.blank?
         %td= conference.title
         %td
           - if show_cfp?(current_user, conference)

--- a/test/tasks/rake_task_export_import_conference_test.rb
+++ b/test/tasks/rake_task_export_import_conference_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'rake'
+
+class RakeTaskExportImportConferenceTest < ActiveSupport::TestCase
+
+  describe 'frab:conference_export_import' do
+
+    NEW_ACRONYM = 'imported'.freeze
+    
+    def setup
+      # Create a conference with an attachment
+      @conf = create :three_day_conference_with_events
+      @conf.update_attributes(attachment_title_is_freeform: false)
+    
+      @event=@conf.events.first
+    
+      upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'textfile.txt'), 'text/plain')
+      @event.update_attributes( event_attachments_attributes: { 'xx' => { 'title' => 'proposal', 'attachment' => upload } })
+    
+      FileUtils.rm_rf('tmp/frab_export')
+    
+      # Run frab:conference_export
+      Frab::Application.load_tasks if Rake::Task.tasks.empty?
+      ENV['CONFERENCE']=@conf.acronym
+      Rake::Task["frab:conference_export"].invoke
+    
+      # Edit the export file to use a different acronym and title
+      # otherwise it would not import
+      data = YAML.load_file "tmp/frab_export/conference.yaml"
+      data["acronym"] = NEW_ACRONYM
+      data["title"] = "NewTitle"
+      File.open("tmp/frab_export/conference.yaml", 'w') { |f| YAML.dump(data, f) }
+    
+      # Run frab:conference_import
+      Rake::Task["frab:conference_import"].invoke
+    end
+    
+    def teardown
+      @conf.destroy
+      @new_conf.destroy
+    end
+    
+    it "should export and import correctly" do
+      @new_conf = Conference.find_by(acronym: NEW_ACRONYM)
+      assert @new_conf, "imported successfully"
+    
+      assert @new_conf.events.count == @conf.events.count, "all events restored"
+    
+      assert( @conf.events.joins(:event_attachments).pluck(:title, :attachment_file_name, :attachment_file_size) ==
+              @new_conf.events.joins(:event_attachments).pluck(:title, :attachment_file_name, :attachment_file_size) ,
+              "all event attachments restored" )
+    
+      conf_attrs = @conf.attributes
+      new_conf_attrs = @new_conf.attributes
+    
+      attributes_to_compare = conf_attrs.keys
+      attributes_to_compare -= [ "id" ] # Updated during re-import
+      attributes_to_compare -= [ "acronym", "title" ] # Updated by this test
+      attributes_to_compare -= [ "created_at", "updated_at" ] # Modified to import time
+    
+      attributes_to_compare.each { |attr|
+        original = conf_attrs[attr]
+        imported = new_conf_attrs[attr]
+        assert original == imported, "conference #{attr} should be identical. original is #{original} ; imported is #{imported}"
+      }
+    end
+  end
+end


### PR DESCRIPTION
Addresses #642 

1. Fix exception in the welcome page, if there's a conference with `start_date` or `end_date` = null.

2. Fix silenced exception if conference `start_date` and `end_date` calculation

3. Add an integration test which created a conference, exports it, imports it to a new name, and compares the new and old copies. This test fails without the other fixes in this PR.

4. `frab:conference_import` worked by disabling many callbacks, but never enabled them back. This caused tests to fail (because necessary callbacks were disabled). Now the import will re-eanble the callbacks it disables.