### PR TITLE
remove deprecated warning

### DIFF
--- a/test/features/can_access_home_test.rb
+++ b/test/features/can_access_home_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 feature 'CanAccessHome' do
   scenario 'home page shows' do
     visit root_path
-    page.must_have_content 'frab'
+    assert_content page, 'frab'
   end
 
   scenario 'home page shows when js is enabled', js: true do
     visit root_path
-    page.must_have_content 'frab'
+    assert_content page, 'frab'
   end
 end


### PR DESCRIPTION
```
DEPRECATED: global use of must_have_content from test/features/can_access_home_test.rb:6. Use _(obj).must_have_content instead. This will fail in Minitest 6.

DEPRECATED: global use of must_have_content from test/features/can_access_home_test.rb:11. Use _(obj).must_have_content instead. This will fail in Minitest 6.
```