### PR TITLE
fix frab#512

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,7 @@ class ApplicationController < ActionController::Base
 
   def default_url_options
     result = { locale: params[:locale] }
-    result[:conference_acronym] = @conference.acronym if @conference
+    result[:conference_acronym] = @conference.persisted_acronym if @conference
     result
   end
 

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -225,6 +225,10 @@ class Conference < ApplicationRecord
     acronym
   end
   
+  def persisted_acronym
+    changed_attributes['acronym'] || acronym
+  end
+
   def allowed_event_timeslots
     return parent.allowed_event_timeslots if sub_conference?
     (allowed_event_timeslots_csv || '').split(',').map(&:to_i)


### PR DESCRIPTION
The problem is that `@conference` is used for two purposes
(1) filling in the texboxes in the settings page
(2) creating internal links.

This PR changes (2) to use only the acronym which has been persisted and ignore whatever local changes were made and not saved.

Closes #512 