### PR TITLE
highlight notifications in cfp page

### DIFF
--- a/app/assets/stylesheets/frab.css.scss
+++ b/app/assets/stylesheets/frab.css.scss
@@ -322,3 +322,9 @@ div.filters-row {
     color: red;
     margin-left: auto;
 }
+
+p.warning {
+    background: #fbbebe
+}
+
+

--- a/app/views/call_for_participations/show.html.haml
+++ b/app/views/call_for_participations/show.html.haml
@@ -15,7 +15,7 @@
         %p= t('cfp.show.dates_hint', {start_date: l(@conference.call_for_participation.start_date), end_date: l(@conference.call_for_participation.end_date)})
 
       - if @conference.days.empty?
-        %p
+        %p.warning
           %b= t('cfp.show.conference_empty_days')
 
       - if @conference.call_for_participation&.hard_deadline_over?
@@ -23,7 +23,7 @@
           %b= t('cfp.show.deadline_passed')
 
       - if @conference.call_for_participation&.still_running? && @conference.call_for_participation.welcome_text.blank?
-        %p
+        %p.warning
           %b= t('cfp.show.empty_description')
 
   .row


### PR DESCRIPTION
This PR changes the warning messages in the cfp page, so that they are more prominent.

![image](https://user-images.githubusercontent.com/20379005/69578225-b8713180-0fd8-11ea-8b61-a8f370fb3849.png)
