### PR TITLE
Improve tests for review_metrics

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -59,11 +59,23 @@ class Event < ApplicationRecord
     end
     e
   }
+  
+  def self.ransackable_attributes(auth_object = nil)
+    column_names + ReviewMetric.all.map(&:safe_name)
+  end
+  
+  def self.ransortable_attributes(auth_object = nil)
+    column_names + ReviewMetric.all.map(&:safe_name)
+  end
 
-  ReviewMetric.all.each do |rm|
+  def self.add_ransacker(rm)
     ransacker rm.safe_name do
       Arel.sql(rm.safe_name)
     end
+  end
+
+  ReviewMetric.all.each do |rm|
+    add_ransacker(rm)
   end
 
   has_paper_trail

--- a/app/models/review_metric.rb
+++ b/app/models/review_metric.rb
@@ -3,6 +3,8 @@ class ReviewMetric < ApplicationRecord
   has_many :review_score, dependent: :destroy
   has_many :average_review_score, dependent: :destroy
   
+  before_save :update_events_ransacker
+  
   has_paper_trail meta: { associated_id: :conference_id, associated_type: 'Conference' }
 
   def to_s
@@ -13,6 +15,10 @@ class ReviewMetric < ApplicationRecord
     # safe_name is used as an sql term, and also as a request parameter.
     # So we try to have it similiar to the review metric name.
     name.parameterize.gsub(%r{[^a-z0-9]}, '_').gsub(%r{^(?=[0-9])}, '_').presence || "rm#{id}"
+  end
+  
+  def update_events_ransacker
+    Event.add_ransacker(self)
   end
 
   validates :name, presence: true, uniqueness: { scope: :conference }

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -45,6 +45,12 @@ FactoryBot.define do
     comment { 'blah' }
   end
 
+  factory :review_score do
+    event_rating
+    review_metric
+    score { 4 }
+  end
+
   factory :event_feedback do
     rating { 3.0 }
     comment { 'doh' }

--- a/test/factories/conference.rb
+++ b/test/factories/conference.rb
@@ -66,6 +66,32 @@ FactoryBot.define do
     end
   end
 
+  trait :with_review_metrics do
+    after :create do |conference|
+      2.times do
+        review_metric = create(:review_metric, conference: conference)
+        review_metric.save
+      end
+    end
+  end
+
+
+  trait :with_reviews do
+    after :create do |conference|
+      reviewer = create(:person)
+      score = 1
+      conference.events.each do |event|
+        conference.review_metrics.each do |review_metric|
+          event_rating = create(:event_rating, event: event, rating: score)
+          create(:review_score, event_rating: event_rating, review_metric: review_metric, score: score)
+          
+          score += 1
+          score = 1 if score > 5
+        end
+      end
+    end
+  end
+
   trait :with_parent_conference do
     after :create do |conference|
       unless conference.subs.any?
@@ -98,6 +124,9 @@ FactoryBot.define do
     factory :three_day_conference, traits: [:three_days, :with_sub_conference]
     factory :three_day_conference_with_events, traits: [:three_days, :with_rooms, :with_events, :with_sub_conference]
     factory :three_day_conference_with_events_and_speakers, traits: [:three_days, :with_rooms, :with_events, :with_sub_conference, :with_speakers]
+    factory :three_day_conference_with_review_metrics_and_events, traits: [:three_days, :with_rooms, :with_events, :with_review_metrics]
+    factory :three_day_conference_with_review_metrics_and_events_and_reviews, traits: [:three_days, :with_rooms, :with_events, :with_review_metrics, :with_reviews]
+    factory :three_day_conference_with_review_metrics_and_events_and_speakers, traits: [:three_days, :with_rooms, :with_events, :with_review_metrics, :with_sub_conference, :with_speakers]
     factory :sub_conference_with_events, traits: [:with_rooms, :with_events, :with_parent_conference]
     factory :past_days_conference, traits: [:past_three_days]
   end

--- a/test/factories/review_metric.rb
+++ b/test/factories/review_metric.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  sequence :review_metric_name do |n|
+    "Metric#{n}"
+  end
+  
+  factory :review_metric do
+    conference
+    name { generate(:review_metric_name) }
+    description { "The event seems highly ipsum lorem" }
+  end
+end

--- a/test/features/editing_event_review_test.rb
+++ b/test/features/editing_event_review_test.rb
@@ -1,18 +1,16 @@
 require 'test_helper'
 
 class EditingEventReviewTest < FeatureTest
-  REVIEW_METRIC_NAME = 'innovative חדשני'
   setup do
-    @conference = create(:three_day_conference_with_events)
+    @conference = create(:three_day_conference_with_review_metrics_and_events)
     @event = @conference.events.last
-
-    review_metric = ReviewMetric.create(name: REVIEW_METRIC_NAME, conference: @conference)
-    @conference.review_metrics << review_metric
+    @review_metric = @conference.review_metrics.first
 
     # When test start, three people already reviewed it
     [2, 4, 5].each do |score|
-      reviewer=create(:conference_coordinator, conference: @conference)
-      @event.event_ratings_attributes = [{ person: reviewer.person, review_scores_attributes: [{review_metric: review_metric, score: score}] }]
+      reviewer = create(:conference_coordinator, conference: @conference)
+      event_rating = create(:event_rating, event: @event, person: reviewer.person)
+      create(:review_score, event_rating: event_rating, review_metric: @review_metric, score: score)
     end
     @event.save
 
@@ -24,12 +22,12 @@ class EditingEventReviewTest < FeatureTest
      # Test that when @user updates the review score, the average is updated correctly
      sign_in_user(@user)
      visit "/#{@conference.acronym}/events/#{@event.id}/event_rating"
-     find('span', exact_text: '4').find('input').click()
+     find('form').find('div', text: @review_metric.name).find('span', text: '4').find('input').click()
      click_on 'Create Event rating'
      assert_content page, 'saved successfully' 
      
      visit "/#{@conference.acronym}/events/ratings"
-     assert_content page, REVIEW_METRIC_NAME 
+     assert_content page, @review_metric.name 
      assert_content page, '3.75' # average([2,4,4,5])
 
      # Test that filtering by review metric works
@@ -43,12 +41,12 @@ class EditingEventReviewTest < FeatureTest
      assert_content page, 'deleted successfully' 
      
      visit "/#{@conference.acronym}/events/ratings"
-     assert_content page, REVIEW_METRIC_NAME 
+     assert_content page, @review_metric.name 
      assert_content page, '3.67' # average([2,4,5])
 
      # Test that sorting by review metric doesn't assert
-     click_on REVIEW_METRIC_NAME
-     assert_content page, REVIEW_METRIC_NAME
+     click_on @review_metric.name
+     assert_content page, @review_metric.name
      
      
   end

--- a/test/features/editing_event_review_test.rb
+++ b/test/features/editing_event_review_test.rb
@@ -43,11 +43,5 @@ class EditingEventReviewTest < FeatureTest
      visit "/#{@conference.acronym}/events/ratings"
      assert_content page, @review_metric.name 
      assert_content page, '3.67' # average([2,4,5])
-
-     # Test that sorting by review metric doesn't assert
-     click_on @review_metric.name
-     assert_content page, @review_metric.name
-     
-     
   end
 end

--- a/test/features/sorting_event_list_test.rb
+++ b/test/features/sorting_event_list_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class SortingEventListTest < FeatureTest
+  setup do
+    @conference = create(:three_day_conference_with_review_metrics_and_events_and_reviews)
+    @conference.events.each do |event|
+      event.update_attributes(track: create(:track, conference: @conference))
+    end
+    
+    @coordinator = create(:conference_coordinator, conference: @conference)
+    
+    # Upload a file to enable "Attachments" view
+    upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'textfile.txt'), 'text/plain')
+    @conference.events.first.update_attributes( event_attachments_attributes: { 'xx' => { 'title' => 'proposal', 'attachment' => upload } }) 
+  end
+
+  it 'can sort', js: true do
+    sign_in_user(@coordinator.user)
+    visit "/#{@conference.acronym}/events/"
+    find_all(:css, 'ul.tabs li').map(&:text).each do |tabname|
+      click_on tabname
+      find("li", class: "active", text: tabname)
+      
+      find_all(:css, "th a.sort_link").map(&:text).each do |column|
+        click_on column
+        assert_content page, "#{column} ▲"
+        
+        col_index = find('table').find_all('th').index{|th| th.text=="#{column} ▲"}
+        last_sorted_asc = find('table').find_all('tr').last.find_all('td')[col_index].text
+        
+        click_on "#{column}", match: :prefer_exact
+        assert find('table').find_all('tr').first.find_all('th')[col_index].text == "#{column} ▼"
+
+        first_sorted_desc = find('table').find_all('tr')[1].find_all('td')[col_index].text
+        
+        assert last_sorted_asc==first_sorted_desc, "Sorting '#{tabname}' page by '#{column}': '#{last_sorted_asc}' should equal '#{first_sorted_desc}'"
+      end
+    end
+  end
+end


### PR DESCRIPTION
The first commit in this PR "add ransackers explicitly" makes sure any change to a review metric triggers a change in its `ransacker` in `events.rb`. The ransacker is used when sorting the events tables by a review metric. Without this change, `rails frab:add_fake_data` creates non-sortable review metrics which was fixed by relaunching rails. Also some of the tests in this PR would have failed.

The second commit in this PR "reorg tests for review_metric" changes the conference factory to support conference with review metrics and review scores. `test/features/editing_event_review_test.rb` is changed to use this factory

The third commit adds `test/features/sorting_event_list_test.rb`, which iterates through all the sub-tabs in the Events page (ie., All Events, My Events, Attachments, Event Ratings, Feedbacks) and iterates through all the filter links, and makes sure they can sort ascending and descending.

 