### PR TITLE
hotfix: Unbreak Dockerfile: Explicitly set ruby to 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 rvm:
   - 2.4.4
   - 2.6.3
+  - 2.6.5
 env:
   - DB=mysql
   - DB=postgresql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2.6.5
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs file imagemagick git && \


### PR DESCRIPTION
This PR:

(1) Changes `Dockerfile` to use `ruby:2.6.5` instead of `ruby:latest` (which is today 2.7 and does not work)

(2) Adds ruby 2.6.5 to the CI to help finding out if the docker version breaks.

See #688 
It's probably better to merge #690 instead of this PR.