### PR TITLE
fix test 'set ticket server to RT'

### DIFF
--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -14,7 +14,7 @@ class HomeControllerTest < ActionController::TestCase
     assert_response :success
     assert_includes response.body, '>present conference'
     assert_includes response.body, '>future conference'
-    assert_includes response.body, '>future conference sub'
+    assert_includes response.body, ">#{@future.subs.first.title}"
     refute_includes response.body, '>past conference'
     refute_includes response.body, '>other conference'
   end

--- a/test/factories/conference.rb
+++ b/test/factories/conference.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     "frabcon#{n}"
   end
 
+  sequence :conference_title do |n|
+    "FrabCon#{2000+n}"
+  end
+
   trait :three_days do
     after :create do |conference|
       conference.days << create(:day, conference: conference,
@@ -77,13 +81,13 @@ FactoryBot.define do
   trait :with_sub_conference do
     after :create do |conference|
       if conference.main_conference?
-        create(:conference, parent: conference, title: "#{conference.title} sub")
+        create(:conference, parent: conference)
       end
     end
   end
 
   factory :conference do
-    title { 'FrabCon' }
+    title { generate(:conference_title) }
     acronym { generate(:conference_acronym) }
     timeslot_duration { 15 }
     default_timeslots { 4 }

--- a/test/features/editing_conference_test.rb
+++ b/test/features/editing_conference_test.rb
@@ -10,7 +10,7 @@ class EditingConferenceTest < FeatureTest
 
   test 'set ticket server to RT' do
     assert_content page, 'Conferences'
-    visit_conference_settings
+    visit_conference_settings_for(@conference)
     choose('Request Tracker')
     click_on 'Update conference'
     assert_content page, 'Conference was successfully updated.'

--- a/test/support/capybara_helper.rb
+++ b/test/support/capybara_helper.rb
@@ -11,9 +11,11 @@ module CapybaraHelper
     sign_in(user.email, 'frab123')
   end
 
-  def visit_conference_settings(matcher = :first)
+  def visit_conference_settings_for(conference)
     click_on 'Conferences'
-    click_on 'Show', match: matcher
+    within find('tr', text: conference.title) do
+      click_on 'Show'
+    end
     find('ul.nav:eq(2)').click_link('Settings')
   end
 end


### PR DESCRIPTION
Prior to this fix, the test "set ticket server to RT" started with clicking `Show` -> `Settings` to edit a conference's settings, but there was no guarantee that the conference being edited is indeed `@conference`. So it seems to succeed most times but failed occasionally.

This PR changes this so that  the correct conference is being edited.

In order to facilitate that, I changed the conference factory so that conferences are now called `FrabCon2000`, `FrabCon2001` etc. (instead of `FrabCon` and `FrabCon sub`); I had to change 1 other test accordingly.