### PR TITLE
Tickets in RT now start as new and keep their state on outgoing correspondence

### DIFF
--- a/app/lib/ticket_server_adapter/rt_adapter.rb
+++ b/app/lib/ticket_server_adapter/rt_adapter.rb
@@ -24,6 +24,7 @@ module TicketServerAdapter
       ticket = rt.ticket_create('Subject' => args[:title],
                                 'Queue'      => @server.queue,
                                 'Owner'      => 'Nobody',
+				'Status'     => 'resolved',
                                 'Requestors' => args[:requestors].collect { |r| "#{r[:name]} <#{r[:email]}>" })
 
       begin
@@ -50,7 +51,7 @@ module TicketServerAdapter
       begin
         rt.ticket_comment(remote_id, 'Action' => 'correspond', 'Text' => body)
       ensure
-        rt.ticket_update(remote_id, old_ticket.slice('Subject', 'Requestors'))
+        rt.ticket_update(remote_id, old_ticket.slice('Subject', 'Requestors', 'Status'))
       end
     end
   end

--- a/app/lib/ticket_server_adapter/rt_adapter.rb
+++ b/app/lib/ticket_server_adapter/rt_adapter.rb
@@ -24,7 +24,7 @@ module TicketServerAdapter
       ticket = rt.ticket_create('Subject' => args[:title],
                                 'Queue'      => @server.queue,
                                 'Owner'      => 'Nobody',
-				'Status'     => 'resolved',
+                                'Status'     => 'resolved',
                                 'Requestors' => args[:requestors].collect { |r| "#{r[:name]} <#{r[:email]}>" })
 
       begin


### PR DESCRIPTION
This PR is intended to smoothen the user experience when working in the RT interface:

Before this, RT Tickets started out as "open" and would reset to "open", whenever frab would add correspondence. This made it very hard to keep track of Tickets in need of attention, as each Ticket was 'active' by default, even when no outside correspondence was added.

Now each Ticket added by frab will initially be marked "resolved" and can be put into active state by manually adding correspondence from RT or via email.

Whenever frab adds outgoing correspondence via bulk mails, it resets the RT Ticket's state to what it found it at, so that open Tickets will stay open while resolved Tickets remain resolved and will only be "re"-opened, whenever speakers reply by email.