### PR TITLE
make robust

### DIFF
--- a/test/features/can_delete_conference_test.rb
+++ b/test/features/can_delete_conference_test.rb
@@ -10,7 +10,9 @@ class CanDeleteConferenceTest < FeatureTest
     sign_in_user(@admin)
     visit "/conferences?term=#{@conference.acronym}"
     assert_content page, @conference.acronym
-    click_on "destroy"
+
+    find('tr', text: @conference.title).find('a', text: 'destroy').click
+
     assert_no_content page, @conference.acronym
   end
 end


### PR DESCRIPTION
the test failed here, because two "destroy" buttons were visible:

https://travis-ci.org/frab/frab/jobs/650870231?utm_medium=notification&utm_source=github_status

```
Error:
CanDeleteConferenceTest#test_0001_can delete conference:
Capybara::Ambiguous: Ambiguous match, found 2 elements matching visible link or button "destroy"
    test/features/can_delete_conference_test.rb:13:in `block in <class:CanDeleteConferenceTest>'
bin/rails test test/features/can_delete_conference_test.rb:9

```