### PR TITLE
remove deprecated devise_error_messages!

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -10,7 +10,7 @@
 
       = simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
 
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
 
         %fieldset.inputs
           = f.input :email, autofocus: true

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -9,7 +9,7 @@
     .span16
       = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, defaults:{error: false}) do |f|
 
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
 
         %fieldset.inputs
           = f.hidden_field :reset_password_token

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -8,7 +8,7 @@
   .row
     .span16
       = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
         %fieldset.inputs
           = f.input :email
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -9,7 +9,7 @@
   .row
     .span16
       = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, defaults:{error: false}) do |f|
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
 
         %fieldset.inputs
           = f.input :email

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,7 +10,7 @@
 
       =simple_form_for(resource, as: resource_name, url: registration_path(resource_name), defaults:{error: false}) do |f|
 
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
 
         %fieldset.inputs
           = f.input :email

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -8,7 +8,7 @@
   .row
     .span16
       = simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, defaults:{error: false}) do |f|
-        = devise_error_messages!
+        = render partial: 'devise/shared/error_messages', resource: resource
 
         %fieldset.inputs
           = f.input :email


### PR DESCRIPTION
This PR fixes a bunch of depracation warnings from devise, such as this one.

```
DEPRECATION WARNING: [Devise] `DeviseHelper.devise_error_messages!`
is deprecated and it will be removed in the next major version.
To customize the errors styles please run `rails g devise:views` and modify the
`devise/shared/error_messages` partial.
 (called from block in _app_views_devise_registrations_new_html_haml___1771282455448882290_232640 at /home/travis/build/eladeyal-intel/frab/app/views/devise/registrations/new.html.haml:13)
```

No visible difference in application output:

![image](https://user-images.githubusercontent.com/20379005/75711240-b81abd80-5cce-11ea-84b6-70d7605876a1.png)
