### PR TITLE
fix filter by blank string

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -64,7 +64,7 @@ class EventsController < BaseConferenceController
     case @filter.type
     when :text
       @options = helpers.localized_filter_options(@conference.events.includes(:track).distinct.pluck(@filter.attribute_name), @filter.i18n_scope)
-      @selected_values = helpers.split_filter_string(params[@filter.qname]) if params[@filter.qname].present?
+      @selected_values = helpers.split_filter_string(params[@filter.qname]) if params[@filter.qname]
     when :range
       @op, @current_numeric_value = helpers.get_op_and_val(params[@filter.qname])
     end
@@ -338,7 +338,7 @@ class EventsController < BaseConferenceController
   def search(events)
     filter = events
     helpers.filters_data.each do |f|
-      if params[f.qname].present?
+      if params[f.qname]
         filter = filter.where(f.attribute_name => criteria_from_param(f))
       end
     end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -69,10 +69,11 @@ module EventsHelper
 
   def show_filters_pane?
     filters_data.each do |f|
-      return true if params[f.qname].present?
+      return true if params[f.qname]
     end
     false
   end
+  
   def localized_filter_options(c, i18n_scope)
     c = split_filter_string(c) if c.is_a? String
     options = (c - ['',nil]).map{|v| [ if i18n_scope 
@@ -88,6 +89,7 @@ module EventsHelper
   end
   
   def split_filter_string(s)
+    return [''] if s==''
     s.split('|', -1)
   end
 

--- a/app/views/events/_filters.html.haml
+++ b/app/views/events/_filters.html.haml
@@ -2,7 +2,7 @@
   %div.filters-row
     %b= t('col_filters')
     - filters_data.each do |f|
-      - if params[f.qname].present?
+      - if params[f.qname]
         %span{:class => 'filterbox'}
           = link_to "╳", request.query_parameters.except(f.qname), class: 'filterbox-close-btn'
           = f.filter_name || t(f.filter_name_i18n)


### PR DESCRIPTION
This PR fixes a bug from #579.

To reproduce the bug: Create two events. 1 with track field empty and 1 with track field populated. Open All Events. Click the filter item next to Track. Check V next to "(blank)", hit OK. It will not filter correctly.

So this fixes it.