### PR TITLE
Warn when importing a conference exported by an older version of frab

### DIFF
--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -17,6 +17,7 @@ class ImportExportHelper
     FileUtils.mkdir_p(@export_dir)
 
     ActiveRecord::Base.transaction do
+      save_schema_version
       dump 'conference', @conference
       dump 'conference_tracks', @conference.tracks
       dump 'conference_cfp', @conference.call_for_participation
@@ -156,6 +157,8 @@ class ImportExportHelper
   end
 
   def restore_conference_data
+    check_schema_version_on_import
+
     restore_multiple('conference_tracks', Track) do |id, obj|
       obj.conference_id = @conference_id
       obj.save!
@@ -300,8 +303,10 @@ class ImportExportHelper
     File.open(File.join(@export_dir, name) + '.yaml', 'w') { |f|
       if obj.respond_to?('collect')
         f.puts obj.collect(&:attributes).to_yaml
-      else
+      elsif obj.respond_to?('attributes')
         f.puts obj.attributes.to_yaml
+      else
+        f.puts obj.to_yaml
       end
     }
     obj
@@ -367,6 +372,22 @@ class ImportExportHelper
   def unpack_paperclip_files
     path = File.join(@export_dir, 'attachments.tar.gz')
     system('tar', *['-xz', '-f', path, '-C', @export_dir].flatten)
+  end
+
+  def save_schema_version
+    dump 'schema_version', ActiveRecord::Migrator.current_version
+  end
+
+  def check_schema_version_on_import
+    importing_version = read_yaml_from_file('schema_version')
+    return if importing_version == ActiveRecord::Migrator.current_version
+
+    if not importing_version
+      puts "WARNING: You are importing data created with an older version of frab."
+    else
+      puts "WARNING: You are importing data created with frab with schema version #{importing_version}"
+    end
+    puts "The import may be incomplete and/or incorrect (but can be OK also.)"
   end
 
   def disable_callbacks

--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -307,19 +307,23 @@ class ImportExportHelper
     obj
   end
 
-  def restore(name, obj)
+  def read_yaml_from_file(name)
     puts "[ ] restore #{name}" if verbose?
     file = File.join(@export_dir, name) + '.yaml'
     return unless File.readable? file
-    records = YAML.load_file(file)
+    YAML.load_file(file)
+  end
+
+  def restore(name, obj)
+    records = read_yaml_from_file(name)
+    return unless records
     tmp = obj.new(records)
     tmp.id = nil
     yield records['id'], tmp
   end
 
   def restore_multiple(name, obj)
-    puts "[ ] restore all #{name}" if verbose?
-    records = YAML.load_file(File.join(@export_dir, name) + '.yaml')
+    records = read_yaml_from_file(name)
     records.each do |record|
       tmp = obj.new(record)
       tmp.id = nil
@@ -328,8 +332,7 @@ class ImportExportHelper
   end
 
   def restore_users(name = 'users', obj = User)
-    puts "[ ] restore all #{name}" if verbose?
-    records = YAML.load_file(File.join(@export_dir, name) + '.yaml')
+    records = read_yaml_from_file(name)
     records.each do |record|
       tmp = obj.new(record)
       tmp.id = nil


### PR DESCRIPTION
When exporting a conference, it will now create a file ` tmp/frab_export/schema_version.yaml` with the schema version (which is updated on every `db:migrate`). On import, if this version mismatches the current version, a warning message is presented to the user (but the import will attempt anyway)

closes #642 

