### PR TITLE
Longer allowed_event_timeslots_csv db field

### DIFF
--- a/db/migrate/20191116151919_add_allowed_event_timeslots_to_conferences.rb
+++ b/db/migrate/20191116151919_add_allowed_event_timeslots_to_conferences.rb
@@ -1,7 +1,7 @@
 class AddAllowedEventTimeslotsToConferences < ActiveRecord::Migration[5.2]
   def up
-    add_column :conferences, :allowed_event_timeslots_csv, :string
-    
+    add_column :conferences, :allowed_event_timeslots_csv, :longtext
+
     Conference.all.each do |conference|
       conference.update_attributes(allowed_event_timeslots: (1..conference.max_timeslots))
     end

--- a/db/migrate/20200915222257_allowed_event_timeslots_length.rb
+++ b/db/migrate/20200915222257_allowed_event_timeslots_length.rb
@@ -1,0 +1,5 @@
+class AllowedEventTimeslotsLength < ActiveRecord::Migration[5.2]
+  def change
+    change_column :conferences, :allowed_event_timeslots_csv, :longtext
+  end
+end


### PR DESCRIPTION
Fixes 'Mysql2::Error: Data too long for column'