### PR TITLE
WIP: fix migration fail

### DIFF
--- a/db/migrate/20191116151919_add_allowed_event_timeslots_to_conferences.rb
+++ b/db/migrate/20191116151919_add_allowed_event_timeslots_to_conferences.rb
@@ -3,7 +3,12 @@ class AddAllowedEventTimeslotsToConferences < ActiveRecord::Migration[5.2]
     add_column :conferences, :allowed_event_timeslots_csv, :string
     
     Conference.all.each do |conference|
-      conference.update_attributes(allowed_event_timeslots: (1..conference.max_timeslots))
+      conference.update_attributes(allowed_event_timeslots: 
+                                     if conference.max_timeslots < 60
+                                       (1..conference.max_timeslots)
+                                     else
+                                       conference.default_timeslots
+                                  )
     end
   end
 


### PR DESCRIPTION
following frab#651 - migrating some conference might fail since mysql limits
allowed_durations_minutes_csv to 255 characters