### PR TITLE
bump mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
Existing versions were yanked unexpectedly. See https://github.com/minad/mimemagic/issues/97

Note licensce change MIT -> GPLv2