### PR TITLE
fix "confirm" button in CFP (partly)

### DIFF
--- a/app/models/concerns/event_state.rb
+++ b/app/models/concerns/event_state.rb
@@ -59,9 +59,9 @@ module EventState
   end
 
   def process_acceptance(options)
-    if options[:send_mail]
-      event_people.subscriber.each do |event_person|
-        event_person.generate_token!
+    event_people.subscriber.each do |event_person|
+      event_person.generate_token!
+      if options[:send_mail]
         SelectionNotification.make_notification(event_person, 'accept').deliver_now
       end
     end

--- a/app/views/cfp/people/_table.html.haml
+++ b/app/views/cfp/people/_table.html.haml
@@ -34,7 +34,7 @@
           = link_to t("edit"), edit_cfp_event_path(event), class: "btn small"
           - if @conference.event_state_visible || @conference.schedule_open?
             - if event.state == "unconfirmed"
-              = link_to t("cfp.confirm"), confirm_cfp_event_path(event), method: :put, class: "btn success small"
+              = link_to t("cfp.confirm"),  cfp_event_confirm_by_token_path(event.id, token: EventPerson.where(event_id:  event, person: @person).first.confirmation_token), method: :post, class: "btn success small"
             - if event.transition_possible? :withdrawn and event.start_time and event.start_time > Time.now
               = link_to t("cfp.withdraw"), withdraw_cfp_event_path(event), method: :put, confirm: t("cfp.withdrawal_confirmation"), class: "btn danger small"
           - if @conference.schedule_open? && event.transition_possible?(:accept)


### PR DESCRIPTION
This fixes https://github.com/frab/frab/issues/817.

If an event is accepted using "Accept, no mail" - a confirmation token is generated.

The "confirm attendance" button on the CFP list now uses that token to evoke confirmation

(I'm not sure if and how it worked previously)

I also don't have a solution for when the transistion from new -> unconfirmed is perfomed using direct editing of the event rather than by the "accept" button