### PR TITLE
Add sponsorship link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://www.paypal.com/paypalme/MarioManno


### PR DESCRIPTION
@frab/contributors feel free to open a PR to add your funding links. I don't know any sponsors, but I want to make it possible for conferences and individuals to support the project financially.

I'm also talking to FrOSCon e.V. about managing sponsorship for the frab project,  so we can offer [Github sponsoring profile](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/setting-up-github-sponsors-for-your-organization).