### PR TITLE
API extensions

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -221,6 +221,17 @@ class Conference < ApplicationRecord
     events.with_review_averages(self)
   end
 
+  def url_options
+    { protocol: ENV.fetch('FRAB_PROTOCOL'),
+      host: ENV.fetch('FRAB_HOST'), 
+      port: ENV['FRAB_PORT'].presence, 
+      path: "/#{acronym}" }
+  end
+
+  def uri
+    URI::HTTP.build(url_options).to_s
+  end
+
   def to_s
     "#{model_name.human}: #{title} (#{acronym})"
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -67,6 +67,10 @@ class Person < ApplicationRecord
     updated_at > person.updated_at
   end
 
+  def name
+    public_name
+  end
+
   def full_name
     if first_name.blank? or last_name.blank?
       public_name
@@ -77,6 +81,18 @@ class Person < ApplicationRecord
 
   def full_name_annotated
     full_name + " (#{email}, \##{id})"
+  end
+
+  def guid
+    Digest::UUID.uuid_v5(Digest::UUID::URL_NAMESPACE, uri)
+  end
+
+  def uri
+    if email.present?
+      "acct:#{email}" 
+    else
+      URI::HTTP.build({ path: "/people/#{id}", host: ENV.fetch('FRAB_HOST'), protocol: ENV.fetch('FRAB_PROTOCOL'), port: ENV['FRAB_PORT'].presence }).to_s
+    end
   end
 
   def user_email

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -11,4 +11,13 @@ class Room < ApplicationRecord
   def to_s
     "#{model_name.human}: #{name}"
   end
+
+  def guid
+    Digest::UUID.uuid_v5(Digest::UUID::URL_NAMESPACE, uri.to_s)
+  end
+
+  def uri
+    URI::HTTP.build({**conference.url_options, path: "/rooms/#{self.id}"})
+  end
+
 end

--- a/app/policies/conference_policy.rb
+++ b/app/policies/conference_policy.rb
@@ -18,6 +18,7 @@ class ConferencePolicy < ApplicationPolicy
   alias create? orga?
 
   def manage?
+    return false unless user
     return (user.is_admin? || user.any_crew?('orga', 'coordinator')) if record.is_a?(Class)
     user.is_admin? || user.is_manager_of?(record)
   end

--- a/app/views/people/show.json.jbuilder
+++ b/app/views/people/show.json.jbuilder
@@ -1,1 +1,2 @@
 json.partial! 'shared/person', person: @person
+json.origin ENV.fetch('FRAB_HOST')

--- a/app/views/public/schedule/index.json.jbuilder
+++ b/app/views/public/schedule/index.json.jbuilder
@@ -48,7 +48,7 @@ json.schedule do
             json.description event.description
             json.recording_license event.recording_license
             json.do_not_record event.do_not_record
-            json.persons event.speakers, :id, :public_name
+            json.persons event.speakers, :guid, :id, :name, :public_name
             json.links event.links do |link|
               json.url url_for(link.url)
               json.title link.title

--- a/app/views/public/schedule/index.json.jbuilder
+++ b/app/views/public/schedule/index.json.jbuilder
@@ -15,6 +15,11 @@ json.schedule do
     json.daysCount @conference.days.length
     json.timeslot_duration duration_to_time(@conference.timeslot_duration)
     json.time_zone_name @conference.timezone_IANA
+    json.rooms @conference.rooms_including_subs.each do |room|
+      json.name room.name
+      json.guid room.guid
+      json.capacity room.size
+    end
     index = 1
     json.days @conference.days do |day|
       json.index index

--- a/app/views/public/schedule/index.xml.haml
+++ b/app/views/public/schedule/index.xml.haml
@@ -19,7 +19,7 @@
   - @conference.days.each_with_index do |day, index|
     %day{index: (index + 1), date: day.start_date.strftime('%Y-%m-%d'), start: day.start_date.iso8601, end: day.end_date.iso8601}
       - @conference.rooms_including_subs.each do |room|
-        %room{name: room.name}
+        %room{name: room.name, guid: room.guid}
           - room.events.is_public.accepted.scheduled_on(day).order(:start_time).each do |event|
             %event{id: event.id, guid: event.guid}
               %date= event.start_time.iso8601

--- a/app/views/public/schedule/speakers.json.jbuilder
+++ b/app/views/public/schedule/speakers.json.jbuilder
@@ -3,8 +3,8 @@ json.schedule_speakers do
   json.speakers @view_model.speakers do |person|
     json.partial! 'shared/person', person: person
     json.events person.public_and_accepted_events_as_speaker_in(@conference) do |event|
-      json.id event.id
       json.guid event.guid
+      json.id event.id
       json.title event.title
       json.logo event.logo_path
       json.type event.event_type

--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -10,13 +10,5 @@ json.do_not_record event.do_not_record
 json.track event.track&.name
 json.abstract event.abstract
 json.speakers event.speakers do |person|
-  json.id person.id
-  json.image person.avatar_path(:original)
-  json.full_public_name person.public_name
-  json.abstract person.abstract
-  json.description person.description
-  json.links person.links do |link|
-    json.url url_for(link.url)
-    json.title link.title
-  end
+  json.partial! 'shared/person', person: person
 end

--- a/app/views/shared/_event_crew.json.jbuilder
+++ b/app/views/shared/_event_crew.json.jbuilder
@@ -10,3 +10,25 @@ json.attachments event.event_attachments.is_public.each do |attachment|
   json.url attachment.attachment.url
   json.title attachment.link_title
 end
+json.speakers event.speakers do |person|
+  json.partial! 'shared/person', person: person
+  json.state person.role_state(event.conference)
+  json.availabilities person.availabilities_in(event.conference).each do |a|
+    json.start a.start_date.iso8601
+    json.end a.end_date.iso8601
+  end
+  json.url person_url(person)
+  json.public_url url_for(public_event_url(event))
+end
+if event.remote_ticket?
+  json.ticket do
+    json.id event.ticket.remote_ticket_id
+    unless event.conference.ticket_server.nil?
+      json.url get_ticket_view_url(event.ticket.remote_ticket_id)
+    end
+  end
+end
+# techrider, submission_notes?
+json.origin ENV.fetch('FRAB_HOST')
+json.url event_url(event)
+json.public_url public_event_url(event)

--- a/app/views/shared/_person.json.jbuilder
+++ b/app/views/shared/_person.json.jbuilder
@@ -12,7 +12,7 @@ json.links person.links do |link|
   json.url url_for(link.url)
   json.title link.title
 end
-if policy(Conference).manage?
+if @request and policy(Conference).manage?
   json.full_name person.full_name
   json.email person.email
   json.contacts do

--- a/app/views/shared/_person.json.jbuilder
+++ b/app/views/shared/_person.json.jbuilder
@@ -12,3 +12,17 @@ json.links person.links do |link|
   json.url url_for(link.url)
   json.title link.title
 end
+if policy(Conference).manage?
+  json.full_name person.full_name
+  json.email person.email
+  json.contacts do
+    json.array!(person.phone_numbers) do |phone_number|
+      json.type phone_number.phone_type
+      json.identifier phone_number.phone_number
+    end
+    json.array!(person.im_accounts) do |im_account|
+      json.type im_account.im_type
+      json.identifier im_account.im_address
+    end
+  end
+end

--- a/app/views/shared/_person.json.jbuilder
+++ b/app/views/shared/_person.json.jbuilder
@@ -1,7 +1,11 @@
+json.guid person.guid
 json.id person.id
 json.image person.avatar_path(:original)
-json.full_public_name person.public_name
+json.name person.public_name
 json.public_name person.public_name
+if person.email_public?
+  json.email person.email
+end
 json.abstract person.abstract
 json.description person.description
 json.links person.links do |link|

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -58,7 +58,7 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :success
     people = JSON.parse(response.body)['people']
     assert_equal 3, people.count
-    assert_includes people[0].keys, 'full_public_name'
+    assert_includes people[0].keys, 'name'
     assert_includes people[0].keys, 'links'
   end
 
@@ -66,7 +66,7 @@ class PeopleControllerTest < ActionController::TestCase
     get :show, format: :json, params: { id: @person.to_param, conference_acronym: @conference.acronym }
     assert_response :success
     person = JSON.parse(response.body)
-    assert_includes person.keys, 'full_public_name'
+    assert_includes person.keys, 'name'
     assert_includes person.keys, 'links'
   end
 end

--- a/test/integration/static_schedule_export_test.rb
+++ b/test/integration/static_schedule_export_test.rb
@@ -44,6 +44,8 @@ class StaticScheduleExportTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    FileUtils.remove_dir(@dir) if File.exist?(@dir)
+    unless @dir.nil?
+      FileUtils.remove_dir(@dir) if File.exist?(@dir) 
+    end
   end
 end


### PR DESCRIPTION
This PR adds:
* schedule.json/.xml: Room guid's #507
* schedule.json/.xml: Person guid based on hashed emails using uuid_v5 with NS_URL and `acct:user@domain.tld`, inspired by [webfinger](http://webfinger.net)/feediverse
* internal JSON API: more person attributes for orga
* all JSON APIs: deprecating`person.full_name`, recommending `person.name` instead