### PR TITLE
Localized schedule Buttons

### DIFF
--- a/app/controllers/public/schedule_controller.rb
+++ b/app/controllers/public/schedule_controller.rb
@@ -1,20 +1,18 @@
 class Public::ScheduleController < ApplicationController
   layout 'public_schedule'
   before_action :maybe_authenticate_user!
-  before_action :set_lang, except: %i[style qrcode]
+  before_action :set_mobility, except: %i[style qrcode]
   after_action :cors_set_access_control_headers
 
   def index
     @days = @conference.days
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-        format.xml
-        format.xcal
-        format.ics
-        format.json
-      end
+    respond_to do |format|
+      format.html
+      format.xml
+      format.xcal
+      format.ics
+      format.json
     end
   end
 
@@ -35,14 +33,12 @@ class Public::ScheduleController < ApplicationController
 
     @view_model = ScheduleViewModel.new(@conference).for_day(@day)
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-        format.pdf do
-          @layout = CustomPDF::FullPageLayout.new('A4')
-          @rooms_per_page = 5
-          render template: 'schedule/custom_pdf'
-        end
+    respond_to do |format|
+      format.html
+      format.pdf do
+        @layout = CustomPDF::FullPageLayout.new('A4')
+        @rooms_per_page = 5
+        render template: 'schedule/custom_pdf'
       end
     end
   end
@@ -50,65 +46,53 @@ class Public::ScheduleController < ApplicationController
   def events
     @view_model = ScheduleViewModel.new(@conference)
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-        format.json
-        format.xls { render file: 'public/schedule/events.xls.erb', content_type: 'application/xls' }
-      end
+    respond_to do |format|
+      format.html
+      format.json
+      format.xls { render file: 'public/schedule/events.xls.erb', content_type: 'application/xls' }
     end
   end
 
   def timeline
     @view_model = ScheduleViewModel.new(@conference)
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-      end
+    respond_to do |format|
+      format.html
     end
   end
 
   def booklet
     @view_model = ScheduleViewModel.new(@conference)
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-      end
+    respond_to do |format|
+      format.html
     end
   end
 
   def event
     @view_model = ScheduleViewModel.new(@conference).for_event(params[:id])
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-        format.ics
-      end
+    respond_to do |format|
+      format.html
+      format.ics
     end
   end
 
   def speakers
     @view_model = ScheduleViewModel.new(@conference)
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-        format.json
-        format.xls { render file: 'public/schedule/speakers.xls.erb', content_type: 'application/xls' }
-      end
+    respond_to do |format|
+      format.html
+      format.json
+      format.xls { render file: 'public/schedule/speakers.xls.erb', content_type: 'application/xls' }
     end
   end
 
   def speaker
     @view_model = ScheduleViewModel.new(@conference).for_speaker(params[:id])
 
-    Mobility.with_locale(@lang) do
-      respond_to do |format|
-        format.html
-      end
+    respond_to do |format|
+      format.html
     end
   end
 
@@ -136,11 +120,12 @@ class Public::ScheduleController < ApplicationController
     headers['Access-Control-Allow-Origin'] = '*'
   end
 
-  def set_lang
-    @lang = if params[:lang] && @conference.language_codes.include?(params[:lang])
-              params[:lang]
-            else
-              params[:locale]
-            end
+  def set_mobility
+    # setting Mobility.locale is thread-safe and affects only queries, not I18n.locale translations
+    Mobility.locale = if params[:lang] && @conference.language_codes.include?(params[:lang])
+                        params[:lang]
+                      else
+                        params[:locale]
+                      end
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -55,7 +55,7 @@ class ScheduleController < BaseConferenceController
                    when 'portrait'
                      :portrait
                    else
-                      rooms.size > 3 ? :landscape : :portrait
+                     rooms.size > 3 ? :landscape : :portrait
                    end
 
     respond_to do |format|

--- a/app/lib/static_schedule/export.rb
+++ b/app/lib/static_schedule/export.rb
@@ -16,6 +16,7 @@ module StaticSchedule
       @locale = locale || 'en'
       @destination = destination || EXPORT_PATH
 
+      # this does not support all combinations, e.g. cannot show nl event fields with fr locales
       I18n.with_locale(@locale) do
         @renderer = ProgramRenderer.new(@conference, @locale)
         @pages = Pages.new(@renderer, @conference)

--- a/app/views/schedule/index.html.haml
+++ b/app/views/schedule/index.html.haml
@@ -1,7 +1,9 @@
 %section
   .page-header
     .pull-right
-      = action_button "", schedule_button_text, public_schedule_index_path, hint: t('schedule_module.view_live_version_hint')
+      = action_button "", schedule_button_text, public_schedule_index_path(lang: @conference.language_default), hint: t('schedule_module.view_live_version_hint')
+      - @conference.language_codes[1..-1].each do |lang|
+        = action_button "",  "#{lang}", public_schedule_index_path(lang: lang), hint: t('schedule_module.view_live_version_hint')
       = action_button "", t('schedule_module.create_pdf_export'), new_schedule_pdf_path, hint: t('schedule_module.create_pdf_export_hint')
       = action_button "success", t('schedule_module.publish_html_export'), schedule_html_exports_path, hint: t('schedule_module.publish_html_export_hint')
     %h1= t('schedule')

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class EventTest < ActiveSupport::TestCase
   setup do
     ActionMailer::Base.deliveries = []
+    I18n.locale = :en
+    Mobility.locale = nil
   end
 
   def setup_notification_event


### PR DESCRIPTION
This should allow frab to show fields in NL with a FR locale. The set of locales (=UI translations) is limited to de en es fr it 'pr-BR' ru zh. Conference however can store fields in many more languages.