### PR TITLE
update migration & rollback test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,10 +79,11 @@ jobs:
       run: |
         sed -i 's/config.eager_load = .*/config.eager_load = true/' config/environments/test.rb
         bundle exec rails db:schema:load --trace
+        bundle exec rails db:schema:dump
         mv db/schema.rb db/schema.rb.original
         bundle exec rails db:rollback STEP=4
         bundle exec rails db:migrate
-        sh -c "[ '$DB' != 'sqlite' ] || diff db/schema.rb db/schema.rb.original "
+        diff db/schema.rb db/schema.rb.original
         bundle exec rails db:test:prepare
         bundle exec rails test
         bundle exec rails test:system


### PR DESCRIPTION
Current implementation no longer works for Rails 6. The new implementation now
would work on all databases in CI.