### PR TITLE
Use a shared footer partial in all layouts

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,7 +37,5 @@
       .main-content
         = render 'shared/flash', flash: flash
         = yield
-    %footer.footer
-      .container
-        - if content_for? :footer
-          = yield :footer
+
+    = render 'shared/footer'

--- a/app/views/layouts/cfp.html.haml
+++ b/app/views/layouts/cfp.html.haml
@@ -33,5 +33,5 @@
       .main-content
         = render 'shared/flash', flash: flash
         = yield
-    %footer
-      .container/
+
+    = render 'shared/footer'

--- a/app/views/layouts/conference.html.haml
+++ b/app/views/layouts/conference.html.haml
@@ -27,5 +27,5 @@
       .main-content
         = render 'shared/flash', flash: flash
         = yield
-    %footer.footer
-      .container
+
+    = render 'shared/footer'

--- a/app/views/layouts/signup.html.haml
+++ b/app/views/layouts/signup.html.haml
@@ -19,3 +19,5 @@
     .container
       .main-content
         = yield
+
+    = render 'shared/footer'

--- a/app/views/layouts/team_signup.html.haml
+++ b/app/views/layouts/team_signup.html.haml
@@ -19,3 +19,5 @@
     .container
       .main-content
         = yield
+
+    = render 'shared/footer'

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,0 +1,4 @@
+%footer.footer
+  .container
+    - if content_for? :footer
+      = yield :footer


### PR DESCRIPTION
Well, except in the public schedule.

This should be easy to override, via app/views/custom.