### PR TITLE
Expose event guid in events/export_confirmed (used by halfnarp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Localization for *model fields*, like the event's description is provided by the
 
 If a field has no stored translation, the supported languages will fallback to the `I18n.default_locale`. The unsupported languages, will return nil, until a translation is stored.
 
-Frab uses the models database column, e.g. 'title', for the default language (`I18n.default_locale`), other languages are stored in seperate database tables.
+Frab uses the models database column, e.g. 'title', for the default language (`I18n.default_locale`), other languages are stored in separate database tables.
 Mobility calls that a `column fallback`, it helps with existing installations and avoids JOIN statements if only one language is used.
 
 The default language is assumed to be English (`I18n.default_locale`), but could be changed in an initializer.

--- a/app/views/events/export.json.jbuilder
+++ b/app/views/events/export.json.jbuilder
@@ -1,11 +1,12 @@
 json.array! @events do |e|
   json.event_id e.id
-  json.extract! e, :id, :track_id, :room_id, :start_time, :title, :subtitle, :description, :abstract, :language
+  json.event_url event_url(e)
+  json.public_event_url public_program_event_url(e)
+  json.extract! e, :guid, :id, :track_id, :room_id, :start_time, :title, :subtitle, :description, :abstract, :language
   json.track_name e.track.try(:name)
   json.room_name e.room.try(:name)
   json.duration e.duration_in_minutes
   json.speaker_names e.speakers.map(&:public_name).join(', ')
-  json.event_url event_url(e)
   json.type e.event_type
   json.speakers e.speakers do |speaker|
     json.id speaker.id


### PR DESCRIPTION
e.g. [https://frab.cccv.de/en/37C3/events/export_confirmed?format=json (non-public)](http://localhost:3000/en/cy-gor/events/export_confirmed?format=json)
```json
[
	{
		"public_event_url": "https://fahrplan.events.ccc.de/congress/2023/fahrplan/events/751.html",
		"event_url": "http://localhost:3000/en/cy-gor/events/751",
		"event_id": 751,
		"guid": "1ebda5d2-b46e-4692-a5e2-df99670b0566",
		"id": 751,
		"track_id": 120,
		"room_id": null,
		"start_time": null,
		"title": "Mr Standfast",
		"subtitle": "You can't connect the protocol without connecting the auxiliary HTTP circuit",
		"description": "Sriracha cold-pressed helvetica. Photo booth humblebrag drinking. Lo-fi meditation sriracha butcher quinoa mustache squid. Authentic dreamcatcher etsy beard street wayfarers shoreditch.",
		"abstract": "Hashtag waistcoat cardigan offal marfa tilde deep v pickled. Viral salvia meggings put a bird on it gluten-free letterpress trust fund. Brunch vhs wolf. 8-bit tacos schlitz shoreditch. Chartreuse lumbersexual retro humblebrag selfies health chia.",
		"language": "en",
		"track_name": "mobile",
		"room_name": null,
		"duration": 2700,
		"speaker_names": "cwalter",
		"type": "djset",
		"speakers": […]
		…
	}
]
```