### PR TITLE
Event validates language matches conference

### DIFF
--- a/app/controllers/cfp/events_controller.rb
+++ b/app/controllers/cfp/events_controller.rb
@@ -117,7 +117,7 @@ class Cfp::EventsController < ApplicationController
     end
 
     if @event.nil?
-        return redirect_to cfp_join_event_path, flash: { error: t('cfp.join_token_unknown', token: @token) }
+      return redirect_to cfp_join_event_path, flash: { error: t('cfp.join_token_unknown', token: @token) }
     end
 
     if @event.people.exists?(@person.id)

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -266,4 +266,11 @@ class EventTest < ActiveSupport::TestCase
     end
     assert_equal 'zh', event.reload.title_zh
   end
+
+  test 'cannot add event with another language to conference' do
+    conference = create(:multilingual_conference)
+    event = build(:event, language: 'fr', conference: conference)
+    event.valid?
+    assert_includes event.errors.full_messages, 'Language locale must match a conference locale'
+  end
 end


### PR DESCRIPTION

Refers to https://github.com/frab/frab/issues/960.

This should make an event with an invalid locale impossible.