### PR TITLE
Fix nil average_rating crash in event_ratings#show

### DIFF
--- a/app/views/event_ratings/show.html.haml
+++ b/app/views/event_ratings/show.html.haml
@@ -128,7 +128,8 @@
                 .d-flex.align-items-center.gap-3
                   %span.fw-bold= t('col_total')
                   = render 'shared/star_rating', id: "total_rating", value: @event.average_rating, readonly: true
-                  %span.text-muted= sprintf("(%.1f/5)", @event.average_rating)
+                  - if @event.average_rating
+                    %span.text-muted= sprintf("(%.1f/5)", @event.average_rating)
 
               - if @event_ratings.count >= 1
                 .table-responsive

--- a/test/controllers/event_ratings_controller_test.rb
+++ b/test/controllers/event_ratings_controller_test.rb
@@ -17,6 +17,20 @@ class EventRatingsControllerTest < ActionController::TestCase
     assert_redirected_to event_event_rating_path
   end
 
+  test 'show does not raise when rating is zero and average_rating is nil' do
+    create :event_rating, event: @event, person: @user.person, rating: 0
+    assert_nil @event.reload.average_rating
+    get :show, params: { conference_acronym: @conference.acronym, event_id: @event.id }
+    assert_response :success
+  end
+
+  test 'show does not raise when rating is nil and average_rating is nil' do
+    create :event_rating, event: @event, person: @user.person, rating: nil
+    assert_nil @event.reload.average_rating
+    get :show, params: { conference_acronym: @conference.acronym, event_id: @event.id }
+    assert_response :success
+  end
+
   test 'should update rating' do
     event_rating = create :event_rating, event: @event, person: @user.person
 


### PR DESCRIPTION
When a rating is saved with a zero or nil star value, average_of_nonzeros returns nil and average_rating stays nil in the database. The show view then crashed trying to pass nil to sprintf. Guard the display and add a regression test covering the zero-star case.