### PR TITLE
Enforce 255 character limit on event attachment titles

### DIFF
--- a/app/models/event_attachment.rb
+++ b/app/models/event_attachment.rb
@@ -10,6 +10,7 @@ class EventAttachment < ApplicationRecord
     preserve_files: PRESERVE_FILE_ATTACHMENTS,
   }
 
+  validates :title, length: { maximum: 255 } # matches db/schema.rb event_attachments.title limit
   validates_attachment_size :attachment, less_than: Integer(ENV['FRAB_MAX_ATTACHMENT_SIZE_MB'] || '42').megabytes
   do_not_validate_attachment_file_type :attachment
 


### PR DESCRIPTION
Adds validation to ensure event attachment titles do not exceed 255 characters, matching the database schema. This prevents errors from overlong titles.