### PR TITLE
Enforce rating value limits on event feedback and ratings

### DIFF
--- a/app/models/event_feedback.rb
+++ b/app/models/event_feedback.rb
@@ -3,7 +3,7 @@ class EventFeedback < ApplicationRecord
 
   after_save :update_average
 
-  validates :rating, presence: true
+  validates :rating, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
 
   protected
 

--- a/app/models/event_rating.rb
+++ b/app/models/event_rating.rb
@@ -9,6 +9,7 @@ class EventRating < ApplicationRecord
 
   validates :event, presence: true
   validates :person, presence: true
+  validates :rating, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 5 }, allow_nil: true
 
   accepts_nested_attributes_for :review_scores, allow_destroy: true
 

--- a/lib/tasks/delete_invalid_ratings.rake
+++ b/lib/tasks/delete_invalid_ratings.rake
@@ -1,0 +1,23 @@
+namespace :frab do
+  desc 'Delete invalid rating records (out-of-range values). Use dry_run=1 to preview.'
+  task delete_invalid_ratings: :environment do
+    dry_run = ENV['dry_run'].present?
+
+    invalid_feedbacks = EventFeedback.where('rating IS NULL OR rating < 1 OR rating > 5')
+    invalid_event_ratings = EventRating.where('rating < 0 OR rating > 5')
+    invalid_review_scores = ReviewScore.where('score < 0 OR score > 5')
+
+    puts "Invalid EventFeedback records: #{invalid_feedbacks.count}"
+    puts "Invalid EventRating records: #{invalid_event_ratings.count}"
+    puts "Invalid ReviewScore records: #{invalid_review_scores.count}"
+
+    if dry_run
+      puts 'Dry run — no records deleted.'
+    else
+      invalid_feedbacks.destroy_all
+      invalid_event_ratings.destroy_all
+      invalid_review_scores.destroy_all
+      puts 'Deleted.'
+    end
+  end
+end

--- a/test/controllers/public/feedback_controller_test.rb
+++ b/test/controllers/public/feedback_controller_test.rb
@@ -25,4 +25,14 @@ class Public::FeedbackControllerTest < ActionController::TestCase
     end
     assert_response :success
   end
+
+  test 'feedback with out-of-range rating is rejected' do
+    assert_no_difference 'EventFeedback.count' do
+      post :create, params: { conference_acronym: @conference.acronym, event_id: @event.id, event_feedback: { rating: 6 } }
+    end
+
+    assert_no_difference 'EventFeedback.count' do
+      post :create, params: { conference_acronym: @conference.acronym, event_id: @event.id, event_feedback: { rating: 0 } }
+    end
+  end
 end

--- a/test/models/event_rating_test.rb
+++ b/test/models/event_rating_test.rb
@@ -5,17 +5,28 @@ class EventRatingTest < ActiveSupport::TestCase
     event = create(:event)
     id = event.id
 
-    create(:event_rating, event: event, rating: 8.0)
-    update_average(id)
-    assert_equal 8.0, Event.find(id).average_rating
-
     create(:event_rating, event: event, rating: 4.0)
     update_average(id)
-    assert_equal 6.0, Event.find(id).average_rating
+    assert_equal 4.0, Event.find(id).average_rating
+
+    create(:event_rating, event: event, rating: 2.0)
+    update_average(id)
+    assert_equal 3.0, Event.find(id).average_rating
 
     create(:event_rating, event: event, rating: 3.0)
     update_average(id)
-    assert_equal 5.0, Event.find(id).average_rating
+    assert_equal 3.0, Event.find(id).average_rating
+  end
+
+  test 'rating must be between 0 and 5' do
+    event = create(:event)
+    person = create(:person)
+
+    assert EventRating.new(event: event, person: person, rating: 0).valid?
+    assert EventRating.new(event: event, person: person, rating: 5).valid?
+    assert EventRating.new(event: event, person: person, rating: nil).valid?
+    assert_not EventRating.new(event: event, person: person, rating: -1).valid?
+    assert_not EventRating.new(event: event, person: person, rating: 5.1).valid?
   end
 
   test 'person can only submit one rating per event' do


### PR DESCRIPTION
Restrict event feedback ratings to 1-5 and event ratings to 0-5. This prevents invalid rating values from being saved and ensures data consistency across feedback and rating models.

🤡 