### PR TITLE
Enable Puma control app in Capistrano deployment

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,3 +13,4 @@ set :bundle_without, %w(capistrano development test postgresql sqlite3).join(' '
 set :linked_files, %w(config/database.yml .env.production .ruby-version)
 set :linked_dirs,  %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system app/views/custom)
 
+set :puma_control_app, true


### PR DESCRIPTION
## Summary

- Enables the Puma control app plugin in Capistrano so `pumactl` commands work during deploys

## Test plan

- [ ] Deploy to staging and verify Puma restarts cleanly via Capistrano