### PR TITLE
Use with_valid_rating scope for feedback score calculations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -260,19 +260,6 @@ class Event < ApplicationRecord
     self.language ||= I18n.default_locale.to_s
   end
 
-  def average(rating_type)
-    result = 0
-    rating_count = 0
-    send(rating_type).each do |rating|
-      if rating.rating
-        result += rating.rating
-        rating_count += 1
-      end
-    end
-    return nil if rating_count.zero?
-    result.to_f / rating_count
-  end
-
   def average_of_nonzeros(list)
     return nil unless list
     list=list.select{ |x| x && x>0 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -142,7 +142,7 @@ class Event < ApplicationRecord
   end
 
   def feedback_standard_deviation
-    arr = event_feedbacks.map(&:rating).reject(&:nil?)
+    arr = event_feedbacks.with_valid_rating.pluck(:rating)
     return if arr.count < 1
 
     n = arr.count
@@ -151,7 +151,9 @@ class Event < ApplicationRecord
   end
 
   def recalculate_average_feedback!
-    update(average_feedback: average(:event_feedbacks))
+    ratings = event_feedbacks.with_valid_rating.pluck(:rating)
+    avg = ratings.empty? ? nil : ratings.sum.to_f / ratings.size
+    update(average_feedback: avg)
   end
 
   def recalculate_average_rating!

--- a/app/models/event_feedback.rb
+++ b/app/models/event_feedback.rb
@@ -5,6 +5,8 @@ class EventFeedback < ApplicationRecord
 
   validates :rating, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
 
+  scope :with_valid_rating, -> { where(rating: 1..5) }
+
   protected
 
   def update_average

--- a/lib/tasks/delete_invalid_ratings.rake
+++ b/lib/tasks/delete_invalid_ratings.rake
@@ -3,7 +3,7 @@ namespace :frab do
   task delete_invalid_ratings: :environment do
     dry_run = ENV['dry_run'].present?
 
-    invalid_feedbacks = EventFeedback.where('rating IS NULL OR rating < 1 OR rating > 5')
+    invalid_feedbacks = EventFeedback.where('rating IS NOT NULL AND (rating < 1 OR rating > 5)')
     invalid_event_ratings = EventRating.where('rating < 0 OR rating > 5')
     invalid_review_scores = ReviewScore.where('score < 0 OR score > 5')
 


### PR DESCRIPTION
## Summary

- Extracts a `with_valid_rating` scope on `EventFeedback` to filter out invalid ratings
- Applies the scope in `Event` feedback score calculations so invalid ratings are excluded
- Updates the `delete_invalid_ratings` rake task to use the same scope

## Test plan

- [ ] Verify feedback score calculations exclude out-of-range ratings
- [ ] Run `rails test test/models/event_feedback_test.rb`