### PR TITLE
Fix flaky attachment export test under parallel workers

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,15 @@ class ActiveSupport::TestCase
   # Configure parallel testing with SQLite fork safety
   parallelize(workers: :number_of_processors)
 
+  parallelize_setup do |worker|
+    Paperclip::Attachment.default_options[:path] =
+      ":rails_root/tmp/test_attachments/worker_#{worker}/:class/:attachment/:id_partition/:style/:filename"
+  end
+
+  parallelize_teardown do |worker|
+    FileUtils.rm_rf(Rails.root.join("tmp/test_attachments/worker_#{worker}"))
+  end
+
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   # fixtures :all
 


### PR DESCRIPTION
## Summary

- Paperclip file paths are keyed by DB record ID, so parallel test workers writing to the same filesystem path race each other — one worker's teardown can delete a file another worker is still reading
- Adds `parallelize_setup` to give each worker an isolated storage directory
- Adds `parallelize_teardown` to clean up after each worker

## Test plan

- [ ] `rails test test/tasks/rake_task_export_attachments_test.rb` passes consistently