### PR TITLE
Fix Ransack error when searching mail templates

### DIFF
--- a/app/models/mail_template.rb
+++ b/app/models/mail_template.rb
@@ -21,4 +21,8 @@ class MailTemplate < ApplicationRecord
     job = SendBulkMailJob.new
     job.async.perform(self, filter)
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[conference_id content created_at id name subject updated_at]
+  end
 end

--- a/test/unit/mail_template_test.rb
+++ b/test/unit/mail_template_test.rb
@@ -33,4 +33,15 @@ class MailTemplateTest < ActiveSupport::TestCase
     assert m.body.include? "|last_name #{@speaker.last_name}|"
     assert m.body.include? "|public_name #{@speaker.public_name}|"
   end
+
+  test 'ransack search by name returns matching templates' do
+    results = MailTemplate.ransack(name_cont: @mail_template.name).result
+    assert_includes results, @mail_template
+  end
+
+  test 'ransack search by name excludes non-matching templates' do
+    other = create(:mail_template, conference: @event.conference, name: 'other_template')
+    results = MailTemplate.ransack(name_cont: @mail_template.name).result
+    assert_not_includes results, other
+  end
 end


### PR DESCRIPTION
## Summary

- Define `ransackable_attributes` on `MailTemplate` so Ransack can search by name, subject, and content
- Fixes a `RuntimeError` triggered when any user searched the mail templates index (e.g. `?term=*`)

## Test plan

- [x] Added two unit tests verifying Ransack search returns matching and excludes non-matching templates
- [x] `rails test test/unit/mail_template_test.rb` passes (5 tests, 0 failures)