### PR TITLE
Silence BadRequest exceptions from exception notifier

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,6 +103,7 @@ Rails.application.configure do
     Rails.application.config.middleware.use ExceptionNotification::Rack,
       ignore_if: ->(env, exception) {
         return true if exception.message =~ /^IP spoofing attack/
+        return true if exception.is_a?(ActionController::BadRequest)
         # from https://gist.github.com/jlxw/3357795
         _limit = 1.minute.ago
         if _last_notification > _limit


### PR DESCRIPTION
Malformed multipart/form-data GET requests from scanners raise Rack::Multipart::EmptyContentError, which Rails wraps as ActionController::BadRequest. The controller already handles these with a 400 response and a fail2ban-friendly log line, so the exception notification email is just noise — and it fails to render anyway because the notification template re-triggers the same parse error when accessing filtered_parameters.
