### PR TITLE
Replace dead IM providers with modern ones and add freetext other type

### DIFF
--- a/app/javascript/controllers/im_type_controller.js
+++ b/app/javascript/controllers/im_type_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="im-type"
+export default class extends Controller {
+  static targets = ["select", "other", "hidden"]
+  static values = { otherValue: { type: String, default: "other" } }
+
+  connect() {
+    this.sync()
+  }
+
+  sync() {
+    const isOther = this.selectTarget.value === this.otherValueValue
+    this.otherTarget.style.display = isOther ? "" : "none"
+    this.hiddenTarget.value = isOther ? this.otherTarget.value : this.selectTarget.value
+  }
+}

--- a/app/models/im_account.rb
+++ b/app/models/im_account.rb
@@ -1,5 +1,19 @@
 class ImAccount < ApplicationRecord
-  TYPES = %w(aim icq jabber msn yahoo skype).freeze
+  TYPES = %w(discord irc jabber mastodon matrix signal skype slack telegram whatsapp other).freeze
+
+  # Product names are not translated.
+  LABELS = {
+    'discord' => 'Discord',
+    'irc' => 'IRC',
+    'jabber' => 'Jabber/XMPP',
+    'mastodon' => 'Mastodon',
+    'matrix' => 'Matrix',
+    'signal' => 'Signal',
+    'skype' => 'Skype',
+    'slack' => 'Slack',
+    'telegram' => 'Telegram',
+    'whatsapp' => 'WhatsApp'
+  }.freeze
 
   belongs_to :person
 

--- a/app/views/cfp/people/_im_account_fields.html.haml
+++ b/app/views/cfp/people/_im_account_fields.html.haml
@@ -1,7 +1,7 @@
 .nested-fields
   %fieldset.border.p-3.mb-4
     .d-flex.flex-wrap.gap-3
-      = f.input :im_type, collection: translated_options(ImAccount::TYPES)
+      = render "shared/im_type_field", f: f
       = f.input :im_address
       .d-flex.align-items-end.pb-3
         = remove_association_link :im_account, f

--- a/app/views/shared/_im_account_fields.html.haml
+++ b/app/views/shared/_im_account_fields.html.haml
@@ -2,7 +2,7 @@
   .card.border-secondary.border-opacity-25.mb-3
     .card-body.p-3
       .d-flex.flex-wrap.gap-3
-        = f.input :im_type, collection: translated_options(ImAccount::TYPES)
+        = render "shared/im_type_field", f: f
         = f.input :im_address
         .d-flex.align-items-end.pb-3
           = remove_association_link :im_account, f

--- a/app/views/shared/_im_type_field.html.haml
+++ b/app/views/shared/_im_type_field.html.haml
@@ -1,0 +1,8 @@
+- is_custom = f.object.im_type.present? && !ImAccount::TYPES.include?(f.object.im_type)
+- select_id = "#{f.field_id(:im_type)}_select"
+- type_options = ImAccount::TYPES.map { |type| [ImAccount::LABELS.fetch(type) { t("options.#{type}") }, type] }
+.mb-3{ data: { controller: "im-type" } }
+  %label.form-label{ for: select_id }= ImAccount.human_attribute_name(:im_type)
+  = select_tag nil, options_for_select(type_options, is_custom ? "other" : f.object.im_type), class: "form-select", id: select_id, data: { im_type_target: "select", action: "change->im-type#sync" }
+  = f.hidden_field :im_type, data: { im_type_target: "hidden" }
+  = text_field_tag nil, is_custom ? f.object.im_type : nil, class: "form-control mt-2", placeholder: t('cfp.im_type_other_placeholder'), style: is_custom ? "" : "display:none", data: { im_type_target: "other", action: "input->im-type#sync" }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -302,6 +302,7 @@ de:
     forgot_password_headline: Passwort vergessen?
     hard_deadline_over: Es tut uns sehr leid, aber die Einreichungsfrist ist verstrichen.
     im_accounts: Instant-Messaging-Konto
+    im_type_other_placeholder: Bitte angeben
     info_url_description_html: 'Sind Sie unsicher, was Sie einreichen sollen? Alle Infos zum Call for Participation gibt es hier: %{link}'
     information_headline: Informationen
     input_appreciation: 'Vielen Dank für Ihre Einreichung. Gerne können Sie ein weiteres Event einreichen:'
@@ -1831,7 +1832,6 @@ de:
         delimiter: ''
   options:
     admin: Administrator
-    aim: AIM
     assistant: Assistent
     attending: attending
     bus: Bus
@@ -1847,17 +1847,14 @@ de:
     fax: Fax
     female: weiblich
     film: Film
-    icq: ICQ
     idea: Idee
     integrated: Integriert
-    jabber: Jabber / XMPP
     lecture: Vortrag
     lightning_talk: Lightning Talk
     male: männlich
     meeting: Meeting
     mobile: Mobil
     moderator: Moderator
-    msn: Msn
     offer: Angebot
     orga: Organisator
     other: Andere
@@ -1871,14 +1868,12 @@ de:
     rt: Request Tracker
     secretary: Sekretär/Vorzimmer
     shuttle: Shuttle
-    skype: Skype
     speaker: Sprecher
     submitter: Einreicher
     talk: Vortrag
     unclear: Unklar
     work: Arbeit
     workshop: Workshop
-    yahoo: Yahoo
   others_only: Nur Einreichungen vom Typ 'others'
   page_titles:
     admin_users: frab - Benutzer mit Admininstrator-Rechten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -307,6 +307,7 @@ en:
     forgot_password_headline: Forgot your password?
     hard_deadline_over: Sorry, the deadline for submitting events is over.
     im_accounts: Instant messaging accounts
+    im_type_other_placeholder: Please specify
     info_url_description_html: 'Unsure what to submit? Read all about the Call for Participation at: %{link}'
     information_headline: Information
     input_appreciation: 'We really appreciate your input so far. Feel free to submit or join another event:'
@@ -1864,7 +1865,6 @@ en:
         delimiter: ''
   options:
     admin: Administrator
-    aim: AIM
     assistant: Assistant
     attending: Attending
     bus: Bus
@@ -1880,17 +1880,14 @@ en:
     fax: Fax
     female: Female
     film: Film
-    icq: ICQ
     idea: Idea
     integrated: Integrated
-    jabber: Jabber/XMPP
     lecture: Lecture
     lightning_talk: Lightning talk
     male: Male
     meeting: Meeting
     mobile: Mobile
     moderator: Moderator
-    msn: Msn
     offer: Offer
     orga: Organisator
     other: Other
@@ -1904,14 +1901,12 @@ en:
     rt: Request Tracker
     secretary: Secrétary
     shuttle: Shuttle
-    skype: Skype
     speaker: Speaker
     submitter: Submitter
     talk: Talk
     unclear: Unclear
     work: Work
     workshop: Workshop
-    yahoo: Yahoo
   others_only: Others only
   page_titles:
     admin_users: frab - admin users

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -320,6 +320,7 @@ es:
     forgot_password_headline: Olvidaste tu clave?
     hard_deadline_over: Disculpe, la convocatoria ya ha sido cerrada.
     im_accounts: Cuentas de mensajería instantánea
+    im_type_other_placeholder: Por favor, especifique
     info_url_description_html: "¿No está seguro de qué enviar? Lea las bases de convocatoria en: %{link}"
     information_headline: Información
     input_appreciation: 'Apreciamos su envío. Siéntase en libertad de enviar otro evento:'
@@ -1874,7 +1875,6 @@ es:
         delimiter: ''
   options:
     admin: Administrador
-    aim: OBJETIVO
     assistant: Asistente
     attending: Asistiendo
     bus: Autobús
@@ -1890,17 +1890,14 @@ es:
     fax: fax
     female: femenino
     film: Película
-    icq: ICQ
     idea: Idea
     integrated: Integrado
-    jabber: Jabber / XMPP
     lecture: presentación
     lightning_talk: charla relámpago
     male: masculino
     meeting: reunión
     mobile: móvil
     moderator: Moderador
-    msn: Msn
     offer: Oferta
     orga: Organizador
     other: otra
@@ -1914,14 +1911,12 @@ es:
     rt: Solicitar rastreador
     secretary: asistente
     shuttle: Lanzadera
-    skype: skype
     speaker: Altavoz
     submitter: Peticionario
     talk: Hablar
     unclear: Poco claro
     work: Trabajo
     workshop: taller (hands-on)
-    yahoo: Yahoo
   others_only: Solo otros
   page_titles:
     admin_users: frab - usuarios de administración

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -301,6 +301,7 @@ fr:
     forgot_password_headline: Mot de passe oublié ?
     hard_deadline_over: Désolé mais la date limite de soumission est dépassée.
     im_accounts: Comptes de messagerie instantanée
+    im_type_other_placeholder: Veuillez préciser
     info_url_description_html: 'Pas sûr(e) de ce que vous devez envoyer ? Lisez l’appel à participation ici : %{link}'
     information_headline: Information
     input_appreciation: 'Nous apprécions réellement votre participation. N’hésitez pas à proposer ou à rejoindre un autre évènement :'
@@ -1875,7 +1876,6 @@ fr:
         delimiter: ''
   options:
     admin: Administrateur
-    aim: AIM
     assistant: Assistant
     attending: Assiste
     bus: Bus
@@ -1891,17 +1891,14 @@ fr:
     fax: Fax
     female: Féminin
     film: Film
-    icq: ICQ
     idea: Peut-être
     integrated: Integré
-    jabber: Jabber/XMPP
     lecture: Conférence
     lightning_talk: Conférence éclair
     male: Masculin
     meeting: Meeting
     mobile: Mobile
     moderator: Modérateur
-    msn: Msn
     offer: Demande
     orga: Organisateur
     other: Autre
@@ -1915,14 +1912,12 @@ fr:
     rt: Request Tracker
     secretary: Secrétariat
     shuttle: Navette
-    skype: Skype
     speaker: Orateur
     submitter: Déposant
     talk: Conférence
     unclear: Incertain
     work: Travail
     workshop: Atelier
-    yahoo: Yahoo
   others_only: Autres seulement
   page_titles:
     admin_users: frab - Administrateurs

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -301,6 +301,7 @@ it:
     forgot_password_headline: Hai dimenticato la password?
     hard_deadline_over: Ci dispiace, ma la scadenza per l'invio è scaduta.
     im_accounts: Account di messaggistica istantanea
+    im_type_other_placeholder: Si prega di specificare
     info_url_description_html: 'Non sei sicuro di cosa inviare? Leggi la chiamata per partecipare qui: %{link}'
     information_headline: informazioni
     input_appreciation: 'Apprezziamo molto la tua partecipazione. Non esitate a proporre o partecipare a un altro evento:'
@@ -1879,7 +1880,6 @@ it:
         delimiter: ''
   options:
     admin: amministratore
-    aim: AIM
     assistant: Assistente
     attending: assist
     bus: Pulman
@@ -1895,17 +1895,14 @@ it:
     fax: fax
     female: femminile
     film: film
-    icq: ICQ
     idea: forse
     integrated: integrato
-    jabber: Jabber / XMPP
     lecture: conferenza
     lightning_talk: Conferenza Flash
     male: maschio
     meeting: incontro
     mobile: mobile
     moderator: Moderatore
-    msn: msn
     offer: applicazione
     orga: organizzatore
     other: altro
@@ -1919,14 +1916,12 @@ it:
     rt: Richiedi tracciatore
     secretary: segreteria
     shuttle: navetta
-    skype: Skype
     speaker: altoparlante
     submitter: depositante
     talk: conferenza
     unclear: incerto
     work: lavoro
     workshop: Officina
-    yahoo: Yahoo
   others_only: Solo altro
   page_titles:
     admin_users: frab - Amministratori

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -301,6 +301,7 @@ nl:
     forgot_password_headline: uw wachtwoord vergeten?
     hard_deadline_over: Sorry, de deadline voor het indienen van evenementen is voorbij.
     im_accounts: Instant messaging-accounts
+    im_type_other_placeholder: Specificeer a.u.b.
     info_url_description_html: 'Weet u niet zeker wat u moet indienen? Lees alles over de Oproep tot deelname op: %{link}'
     information_headline: Informatie
     input_appreciation: 'We stellen uw inbreng tot dusver zeer op prijs. Voel je vrij om je in te schrijven of deel te nemen aan een ander evenement:'
@@ -1854,7 +1855,6 @@ nl:
         delimiter: ''
   options:
     admin: Beheerder
-    aim: DOEL
     assistant: Assistent
     attending: Bijwonen
     bus: Bus
@@ -1870,17 +1870,14 @@ nl:
     fax: Fax
     female: Vrouwelijk
     film: Film
-    icq: ICQ
     idea: Idee
     integrated: Geïntegreerd
-    jabber: Jabber/XMPP
     lecture: Lezing
     lightning_talk: Bliksem praten
     male: Mannelijk
     meeting: Ontmoeting
     mobile: mobiel
     moderator: Moderator
-    msn: Msn
     offer: Aanbieding
     orga: organisator
     other: Ander
@@ -1894,14 +1891,12 @@ nl:
     rt: Tracker aanvragen
     secretary: Secretaris
     shuttle: Shuttle
-    skype: Skype
     speaker: Spreker
     submitter: indiener
     talk: Praten
     unclear: Onduidelijk
     work: Het werk
     workshop: werkplaats
-    yahoo: Yahoo
   others_only: Alleen anderen
   page_titles:
     admin_users: frab - admin gebruikers

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -301,6 +301,7 @@ pt-BR:
     forgot_password_headline: Esqueceu sua senha?
     hard_deadline_over: Desculpe-nos, mas o prazo para envio de propostas já acabou.
     im_accounts: Contas de Mensagens Instantâneas
+    im_type_other_placeholder: Por favor, especifique
     info_url_description_html: 'Sem saber o que submeter? Leia tudo sobre a Chamada de Trabalhos em: %{link}'
     information_headline: Informações
     input_appreciation: 'Obrigado por sua submissão recente. Por favor, não hesite em apresentar uma outra proposta:'
@@ -1846,7 +1847,6 @@ pt-BR:
         delimiter: "."
   options:
     admin: Administrador
-    aim: ALVO
     assistant: Assistente
     attending: Atender
     bus: Ônibus
@@ -1862,17 +1862,14 @@ pt-BR:
     fax: fax
     female: mulher
     film: Filme
-    icq: ICQ
     idea: Idéia
     integrated: Integrado
-    jabber: Jabber / XMPP
     lecture: palestra
     lightning_talk: lightning talk
     male: homem
     meeting: reunião
     mobile: celular
     moderator: Moderador
-    msn: Msn
     offer: Oferta
     orga: Organizador
     other: outros
@@ -1886,14 +1883,12 @@ pt-BR:
     rt: Solicitar rastreador
     secretary: secretário
     shuttle: Transporte
-    skype: skype
     speaker: Alto falante
     submitter: Enviado
     talk: Conversa
     unclear: Não claro
     work: Trabalhos
     workshop: oficina
-    yahoo: Yahoo
   others_only: Apenas outros
   page_titles:
     admin_users: frab - usuários admin

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -301,6 +301,7 @@ ru:
     forgot_password_headline: Забыли пароль?
     hard_deadline_over: К сожалению, срок подачи заявок закончился.
     im_accounts: Мгновенные сообщения
+    im_type_other_placeholder: Пожалуйста, уточните
     info_url_description_html: 'Не знаете, что подарить? Читайте все о конкурсе на участие: %{link}'
     information_headline: Информация
     input_appreciation: 'Мы очень ценим ваш вклад до сих пор. Не стесняйтесь подавать или присоединяться к другому событию:'
@@ -1888,7 +1889,6 @@ ru:
         delimiter: ''
   options:
     admin: администратор
-    aim: AIM
     assistant: Ассистент
     attending: Присутствовавший
     bus: автобус
@@ -1904,17 +1904,14 @@ ru:
     fax: факс
     female: женский
     film: фильм
-    icq: ICQ
     idea: идея
     integrated: интегрированный
-    jabber: Jabber / XMPP
     lecture: лекция
     lightning_talk: Молниеносная
     male: мужчина
     meeting: Встреча
     mobile: мобильный
     moderator: Модератор
-    msn: Msn
     offer: Предлагает
     orga: Organisator
     other: Другие
@@ -1928,14 +1925,12 @@ ru:
     rt: Запрос Tracker
     secretary: Секретарь
     shuttle: челнок
-    skype: Skype
     speaker: Оратор
     submitter: податель
     talk: Говорить
     unclear: Не понятно
     work: Работа
     workshop: мастерская
-    yahoo: Yahoo
   others_only: Только другие
   page_titles:
     admin_users: Пользователи frab - admin

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -301,6 +301,7 @@ zh:
     forgot_password_headline: 忘记密码了吗？
     hard_deadline_over: 对不起，提交活动的截止日期已经结束。
     im_accounts: 即时消息帐户
+    im_type_other_placeholder: 请注明
     info_url_description_html: 不确定要提交什么？请阅读%{link}的“参与呼吁”全文
     information_headline: 信息
     input_appreciation: 我们非常感谢您的输入。随意提交或加入其他活动：
@@ -1854,7 +1855,6 @@ zh:
         delimiter: ''
   options:
     admin: 管理员
-    aim: 目标
     assistant: 助理
     attending: 参加
     bus: 总线
@@ -1870,17 +1870,14 @@ zh:
     fax: 传真
     female: 女
     film: 电影
-    icq: ICQ
     idea: 理念
     integrated: 集成
-    jabber: 的Jabber / XMPP
     lecture: 演讲
     lightning_talk: 闪电谈话
     male: 男
     meeting: 会议
     mobile: 移动
     moderator: 主持人
-    msn: MSN
     offer: 提供
     orga: Organisator
     other: 其他
@@ -1894,14 +1891,12 @@ zh:
     rt: 请求跟踪器
     secretary: 秘书
     shuttle: 穿梭
-    skype: Skype的
     speaker: 扬声器
     submitter: 提交
     talk: 谈论
     unclear: 不清楚
     work: 工作
     workshop: 作坊
-    yahoo: 雅虎
   others_only: 仅限其他人
   page_titles:
     admin_users: frab  - 管理员用户

--- a/test/controllers/cfp/people_controller_test.rb
+++ b/test/controllers/cfp/people_controller_test.rb
@@ -5,7 +5,7 @@ class Cfp::PeopleControllerTest < ActionController::TestCase
     @cfp_person = create(:person)
     @call_for_participation = create(:call_for_participation)
     @conference = @call_for_participation.conference
-    login_as(:submitter)
+    @user = login_as(:submitter)
   end
 
   def cfp_person_params
@@ -24,6 +24,17 @@ class Cfp::PeopleControllerTest < ActionController::TestCase
   test 'should get edit' do
     get :edit, params: { conference_acronym: @conference.acronym }
     assert_response :success
+  end
+
+  test 'should get edit with im accounts' do
+    create(:im_account, person: @user.person, im_type: 'telegram', im_address: '@known')
+    create(:im_account, person: @user.person, im_type: 'carrierpigeon', im_address: 'loft 42')
+
+    get :edit, params: { conference_acronym: @conference.acronym }
+    assert_response :success
+
+    assert_select 'select[data-im-type-target="select"] option[value="telegram"]'
+    assert_select 'input[data-im-type-target="other"][value="carrierpigeon"]'
   end
 
   test 'should update cfp_person' do

--- a/test/controllers/people_controller_test.rb
+++ b/test/controllers/people_controller_test.rb
@@ -40,6 +40,17 @@ class PeopleControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should get edit with im accounts' do
+    create(:im_account, person: @person, im_type: 'telegram', im_address: '@known')
+    create(:im_account, person: @person, im_type: 'carrierpigeon', im_address: 'loft 42')
+
+    get :edit, params: { id: @person.to_param, conference_acronym: @conference.acronym }
+    assert_response :success
+
+    assert_select 'select[data-im-type-target="select"] option[value="telegram"]'
+    assert_select 'input[data-im-type-target="other"][value="carrierpigeon"]'
+  end
+
   test 'should update person' do
     put :update, params: { id: @person.to_param, person: person_params, conference_acronym: @conference.acronym }
     assert_redirected_to person_path(assigns(:person))

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -63,6 +63,12 @@ FactoryBot.define do
     conference
   end
 
+  factory :im_account do
+    person
+    im_type { 'telegram' }
+    im_address { '@frab' }
+  end
+
   factory :mail_template do
     conference
     name { 'template one' }


### PR DESCRIPTION
AIM, ICQ, MSN, and Yahoo Messenger have been discontinued for years. Swap them for Discord, IRC, Mastodon, Matrix, Signal, Slack, Telegram, and WhatsApp (keeping Jabber/XMPP and Skype), and let people enter a custom IM type via an "Other" option that reveals a freetext field.