### PR TITLE
Set schedule event box height from event duration

### DIFF
--- a/app/assets/stylesheets/frab.css.scss
+++ b/app/assets/stylesheets/frab.css.scss
@@ -56,6 +56,10 @@ div.event {
   top: 0;
   left: 0;
 
+  /* Box is at least as tall as the event duration (time_slots * 20 - 7);
+     longer content overflows and is faded out by the ::after gradient below */
+  min-height: var(--event-timeslot-height);
+
   /* Create gradient effect when content overflows the time slot height */
   background-clip: padding-box;
 }


### PR DESCRIPTION
Events rendered on page load only received the --event-timeslot-height CSS variable, which controls the overflow gradient but not the box height, so short-content events stayed short regardless of duration. Apply the variable as min-height so the box spans its time slots.