### PR TITLE
Fix event box height when scheduling a new talk

### DIFF
--- a/app/javascript/controllers/schedule_controller.js
+++ b/app/javascript/controllers/schedule_controller.js
@@ -369,10 +369,9 @@ export default class extends Controller {
     })
     .then(response => response.json())
     .then(event => {
-      // Calculate timeslot height based on duration (event.duration is in minutes)
+      // Calculate timeslot height from the event's time slots
       // Formula matches _event.html.haml: time_slots * 20 - 7
-      const timeSlots = Math.ceil(event.duration / 5) // 5 minutes per slot
-      const timeslotHeight = timeSlots * 20 - 7
+      const timeslotHeight = event.time_slots * 20 - 7
 
       // Rebuild the event card HTML to match _event.html.haml
       const colorPreview = `<div class="color-preview" style="background-color: #cccccc"></div>`

--- a/app/views/events/export.json.jbuilder
+++ b/app/views/events/export.json.jbuilder
@@ -5,7 +5,9 @@ json.array! @events do |e|
   json.extract! e, :guid, :id, :track_id, :room_id, :start_time, :title, :subtitle, :description, :abstract, :language
   json.track_name e.track.try(:name)
   json.room_name e.room.try(:name)
-  json.duration e.duration_in_minutes
+  # duration_in_minutes returns an ActiveSupport::Duration; .to_i emits it as
+  # seconds. Kept in seconds for backwards compatibility with API consumers.
+  json.duration e.duration_in_minutes.to_i
   json.speaker_names e.speakers.map(&:public_name).join(', ')
   json.type e.event_type
   json.speakers e.speakers do |speaker|

--- a/app/views/shared/_event.json.jbuilder
+++ b/app/views/shared/_event.json.jbuilder
@@ -4,7 +4,10 @@ json.title event.title
 json.language event.language
 json.subtitle event.subtitle
 json.description event.description
-json.duration event.duration_in_minutes
+# duration_in_minutes returns an ActiveSupport::Duration; .to_i emits it as
+# seconds. Kept in seconds for backwards compatibility with API consumers.
+json.duration event.duration_in_minutes.to_i
+json.time_slots event.time_slots
 json.logo event.logo_path(:original)
 json.type event.event_type
 json.do_not_record event.do_not_record


### PR DESCRIPTION
The schedule controller derived time slots from the JSON duration field, which serializes an ActiveSupport::Duration as seconds, and divided by a hardcoded 5-minute slot. This produced absurd box heights (e.g. 10793px).

Expose time_slots in the event JSON and use it directly, matching the _event.html.haml formula. Serialize duration explicitly with .to_i to keep the seconds value that API consumers expect.