### PR TITLE
Rewrite absolute asset URLs in static export CSS

### DIFF
--- a/app/lib/static_schedule/export.rb
+++ b/app/lib/static_schedule/export.rb
@@ -83,16 +83,41 @@ module StaticSchedule
     end
 
     def copy_stripped_assets
-      @asset_paths.uniq.each do |asset_path|
-        original_path = Rails.root.join('public', CGI.unescape(asset_path))
+      asset_paths = @asset_paths.uniq.map { |path| CGI.unescape(path) }
+      # Array#each sees paths appended during iteration, so assets
+      # referenced from within CSS files get copied as well.
+      asset_paths.each do |asset_path|
+        original_path = Rails.root.join('public', asset_path)
         if File.exist?(original_path)
-          new_path = File.join(@base_directory, CGI.unescape(asset_path))
+          new_path = File.join(@base_directory, asset_path)
           FileUtils.mkdir_p(File.dirname(new_path))
-          FileUtils.cp(original_path, new_path)
+          if asset_path.end_with?('.css')
+            css, referenced = rewrite_css_urls(File.read(original_path))
+            asset_paths.concat(referenced - asset_paths)
+            File.write(new_path, css)
+          else
+            FileUtils.cp(original_path, new_path)
+          end
         elsif Rails.env.production?
           warning('?? We might be missing "%s"' % original_path)
         end
       end
+    end
+
+    # Compiled CSS references other assets (e.g. fonts) by absolute
+    # /assets/ URLs, which break when the export is served from a
+    # subdirectory. Make them relative to the CSS file, which also
+    # lives under assets/, and return the referenced files so they
+    # get copied into the export as well.
+    def rewrite_css_urls(css)
+      referenced = []
+      css = css.gsub(%r{url\((["']?)/assets/([^"')]+)\1\)}) do
+        quote = Regexp.last_match(1)
+        path = Regexp.last_match(2)
+        referenced << "assets/#{path.split(/[?#]/).first}"
+        "url(#{quote}#{path}#{quote})"
+      end
+      [css, referenced]
     end
 
     def copy_static_assets

--- a/test/integration/static_schedule_export_test.rb
+++ b/test/integration/static_schedule_export_test.rb
@@ -47,6 +47,38 @@ class StaticScheduleExportTest < ActionDispatch::IntegrationTest
     assert_includes File.read(@dir.join("events/#{event.id}.html")), 'Introducing frap'
   end
 
+  test 'rewrites absolute asset urls in css' do
+    export = StaticSchedule::Export.new(@conference, 'en', @target_dir)
+    css = '@font-face{src:url(/assets/icons-abc123.woff2) format("woff2"),' \
+          'url("/assets/icons-abc123.woff") format("woff")}'
+
+    rewritten, referenced = export.send(:rewrite_css_urls, css)
+
+    assert_equal '@font-face{src:url(icons-abc123.woff2) format("woff2"),' \
+                 'url("icons-abc123.woff") format("woff")}', rewritten
+    assert_equal %w[assets/icons-abc123.woff2 assets/icons-abc123.woff], referenced
+  end
+
+  test 'copies assets referenced by css and makes their urls relative' do
+    assets_dir = Rails.root.join('public', 'assets')
+    FileUtils.mkdir_p(assets_dir)
+    css_file = assets_dir.join('frab-test-export.css')
+    font_file = assets_dir.join('frab-test-export.woff2')
+    File.write(css_file, 'src:url(/assets/frab-test-export.woff2)')
+    File.write(font_file, 'fake font')
+
+    export = StaticSchedule::Export.new(@conference, 'en', @target_dir)
+    export.instance_variable_set(:@base_directory, @dir.to_s)
+    export.instance_variable_set(:@asset_paths, ['assets/frab-test-export.css'])
+    export.send(:copy_stripped_assets)
+
+    assert_equal 'src:url(frab-test-export.woff2)',
+                 File.read(@dir.join('assets/frab-test-export.css'))
+    assert File.exist?(@dir.join('assets/frab-test-export.woff2'))
+  ensure
+    FileUtils.rm_f([css_file, font_file].compact)
+  end
+
   teardown do
     FileUtils.remove_entry_secure @target_dir if @target_dir
   end


### PR DESCRIPTION
The compiled `public_schedule.css` references the bootstrap-icons fonts by absolute digested URLs (`url(/assets/bootstrap-icons-….woff2)`). The static export copied the CSS verbatim, so exports served from a subdirectory (e.g. `programm.froscon.org/2026/`) requested the fonts from the domain root and 404ed. The font files were also missing from the export entirely, since asset references were only collected from HTML `link`/`script`/`img` tags, not from inside stylesheets.

This makes `StaticSchedule::Export` rewrite `url(/assets/…)` references in copied CSS files to be relative to the CSS file — the CSS and the referenced files both land in the export's `assets/` directory, so relative URLs work under any path prefix — and copies the referenced assets into the export as well.

Fixing the URLs at asset compile time isn't an option: sprockets only serves digested absolute paths in production, so relative URLs would break the dynamic app. Rewriting during export is the one place that knows assets are being relocated.

