### PR TITLE
Auto-merge Dependabot PRs after CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.repository == 'frab/frab' && github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve Dependabot PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow (modeled on voctoweb's) that approves Dependabot PRs and enables auto-merge on them, so they land automatically once the required status checks pass.

Notes:
- Repo already has *Allow auto-merge* enabled and strict required checks (tests 3.2 × sqlite/mysql/postgresql) on `main`, so auto-merge only fires on green CI against an up-to-date branch.
- `main` requires one approving review; the approve step covers that (the repo's Actions setting *Allow GitHub Actions to create and approve pull requests* is enabled).
- Applies to all Dependabot PRs (gems and actions, including majors), same as voctoweb. If we want human review for major bumps, this can be gated with `dependabot/fetch-metadata` on `update-type`.

