### PR TITLE
Fix event durations and room order in public schedule

### DIFF
--- a/app/views/public/schedule/day.html.haml
+++ b/app/views/public/schedule/day.html.haml
@@ -57,7 +57,7 @@
                                     = event.room.name
                                   - if event.time_slots
                                     %span.badge.bg-light.text-dark.small
-                                      = "#{event.time_slots * 15}min"
+                                      = "#{event.time_slots * @conference.timeslot_duration}min"
 
                                 %h6.card-title.mb-2.lh-sm
                                   = link_to event.title, public_event_path(id: event.id), class: "text-decoration-none text-dark fw-semibold stretched-link", style: "font-size: 0.85rem;"
@@ -89,7 +89,7 @@
                 .me-3.text-center.text-muted.small{style: "min-width: 60px;"}
                   = l event.start_time, format: :time
                   %br
-                  %small= "#{event.time_slots * 15}m"
+                  %small= "#{event.time_slots * @conference.timeslot_duration}m"
                 .flex-grow-1
                   .event{class: track_class(event)}
                     %h6.mb-1

--- a/app/views/public/schedule/index.html.haml
+++ b/app/views/public/schedule/index.html.haml
@@ -27,7 +27,7 @@
           = l day.start_date, format: :long
 
       / Create a responsive schedule grid
-      - day_events = @conference.events.scheduled.joins(:room).where(start_time: day.start_date.beginning_of_day..day.start_date.end_of_day).includes(:people, :room, :translations, track: :translations).order(:start_time)
+      - day_events = @conference.events.scheduled.joins(:room).where(start_time: day.start_date.beginning_of_day..day.start_date.end_of_day).includes(:people, :room, :translations, track: :translations).order(:start_time, 'rooms.name')
       - if day_events.any?
         - day_events.group_by(&:start_time).each do |start_time, events|
           .mb-5
@@ -47,7 +47,7 @@
                           = event.room.name
                         - if event.time_slots
                           %span.badge.bg-light.text-dark.small
-                            = "#{event.time_slots * 15}min"
+                            = "#{event.time_slots * @conference.timeslot_duration}min"
 
                       %h5.card-title.mb-2.lh-sm
                         = link_to event.title, public_event_path(id: event.id), class: "text-decoration-none stretched-link text-dark"

--- a/app/views/public/schedule/speaker.html.haml
+++ b/app/views/public/schedule/speaker.html.haml
@@ -55,7 +55,7 @@
                         = l(event.start_time, format: :time)
                     - if event.time_slots
                       .duration.text-center.small.text-muted
-                        = "#{event.time_slots * 15} min"
+                        = "#{event.time_slots * @conference.timeslot_duration} min"
 
                   .session-info
                     .title.fw-semibold.mb-2= event.title


### PR DESCRIPTION
Fixes two problems in the public schedule (also affects preview and static export):

- **Wrong event durations**: the public schedule views hardcoded 15 minutes per time slot, so conferences with a different `timeslot_duration` showed wrong values, e.g. 180min instead of 60min with 5-minute slots. Durations are now computed from the conference's timeslot duration (overview, day, and speaker pages).
- **Inconsistent room order on the overview page**: events were only ordered by start time, so the room order varied from row to row. Each time row is now sorted by room name.