### PR TITLE
Restart puma after capistrano deploys

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,4 +13,5 @@ set :bundle_without, %w(capistrano development test postgresql sqlite3).join(' '
 set :linked_files, %w(config/database.yml .env.production .ruby-version)
 set :linked_dirs,  %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system app/views/custom)
 
-set :puma_control_app, true
+# tmp/pids is a linked dir, so the state file survives across releases
+set :puma_state_path, -> { shared_path.join('tmp', 'pids', 'puma.state') }

--- a/lib/capistrano/tasks/puma.rake
+++ b/lib/capistrano/tasks/puma.rake
@@ -1,0 +1,12 @@
+namespace :puma do
+  desc 'Restart puma via its control app (no sudo needed)'
+  task :restart do
+    on roles(:web) do
+      within current_path do
+        execute :bundle, :exec, :pumactl, '-S', fetch(:puma_state_path), 'restart'
+      end
+    end
+  end
+end
+
+after 'deploy:finished', 'puma:restart'


### PR DESCRIPTION
## Problem

Deploys stopped restarting puma when capistrano3-puma moved past 4.x: the base plugin no longer registers a restart hook (that moved to the `Capistrano::Puma::Systemd` sub-plugin), and `set :puma_control_app, true` is a 4.x-only setting that 6.x silently ignores. Every deploy required a manual restart afterwards.

## Change

- Add a `puma:restart` task in `lib/capistrano/tasks/puma.rake` (already imported by the Capfile) that signals the running server via `pumactl` and the control app state file, hooked `after 'deploy:finished'`.
- Replace the dead `puma_control_app` setting with `puma_state_path`, pointing at the state file in the shared dir (`tmp/pids` is a linked dir, so it survives releases).

Going through the control app keeps the deploy user free of sudo/systemd permissions.

## Server prerequisites

The server's puma config must set:

- `state_path` matching `puma_state_path`
- `activate_control_app`
- `directory` pointing at the capistrano `current` symlink, so hot restarts boot the newly deployed release instead of the release dir the process originally started in

Verified with `cap production deploy --dry-run`, which now runs `bundle exec pumactl -S <shared>/tmp/pids/puma.state restart` after `deploy:finished`.