### PR TITLE
Truncate long track names in public schedule pills

### DIFF
--- a/app/assets/stylesheets/public_schedule.scss
+++ b/app/assets/stylesheets/public_schedule.scss
@@ -334,6 +334,17 @@ body {
   box-shadow: 0 2px 8px var(--frab-shadow) !important;
 }
 
+// Truncate long track names in pills/badges (full name stays in title attribute)
+.track-name-truncate {
+  display: inline-block;
+  // CSS min(); uppercase so libsass (compile + compress passes) doesn't evaluate it
+  max-width: MIN(14rem, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
 // Timeline and list views
 .time-block {
   border-radius: 8px !important;

--- a/app/views/public/schedule/_events_by_track.html.haml
+++ b/app/views/public/schedule/_events_by_track.html.haml
@@ -10,9 +10,9 @@
         - tracks_to_show.sort_by { |e| e.name }.each do |track|
           - if track.events.count > 0
             .col-auto
-              %a.btn.btn-outline-primary.btn-sm{href: "##{track.name.downcase}", class: "track-#{track.name.parameterize}"}
+              %a.btn.btn-outline-primary.btn-sm{href: "##{track.name.downcase}", class: "track-#{track.name.parameterize}", title: track.name}
                 %i.bi.bi-tag.me-1
-                = track.name
+                %span.track-name-truncate= track.name
                 %span.badge.bg-primary.ms-1= track.events.count
 
 .row.mb-4
@@ -50,7 +50,7 @@
                 .text-muted.small.mb-2
                   = truncate(event.abstract, length: 120, separator: ' ')
               .d-flex.flex-wrap.gap-2.align-items-center
-                %span.badge{class: "bg-secondary track-#{track.name.parameterize}"}
+                %span.badge.track-name-truncate{class: "bg-secondary track-#{track.name.parameterize}", title: event.track.try(:name)}
                   = event.track.try(:name)
                 - if event.start_time.present?
                   %span.badge.bg-info

--- a/app/views/public/schedule/_track_menu.html.haml
+++ b/app/views/public/schedule/_track_menu.html.haml
@@ -10,9 +10,9 @@
         .d-flex.flex-wrap.gap-2
           - tracks_to_show.sort_by { |e| e.name }.each do |track|
             .col-auto
-              %a.btn.btn-outline-primary.btn-sm{href: "##{track.name.downcase}", class: "track-#{track.name.parameterize}"}
+              %a.btn.btn-outline-primary.btn-sm{href: "##{track.name.downcase}", class: "track-#{track.name.parameterize}", title: track.name}
                 %i.bi.bi-tag.me-1
-                = track.name
+                %span.track-name-truncate= track.name
                 %span.badge.bg-primary.ms-1= track.events.count
 
 

--- a/app/views/public/schedule/day.html.haml
+++ b/app/views/public/schedule/day.html.haml
@@ -69,7 +69,7 @@
                                       = event.speakers.map(&:public_name).join(", ").truncate(40)
 
                                   - if event.track.present?
-                                    %span.badge.bg-secondary.small.float-end= event.track.name
+                                    %span.badge.bg-secondary.small.float-end.track-name-truncate{title: event.track.name}= event.track.name
 
                       - else
                         %td.empty-cell &nbsp;

--- a/app/views/public/schedule/index.html.haml
+++ b/app/views/public/schedule/index.html.haml
@@ -63,7 +63,7 @@
 
                       .mt-2
                         - if event.track.present?
-                          %span.badge.bg-secondary.small= event.track.name
+                          %span.badge.bg-secondary.small.track-name-truncate{title: event.track.name}= event.track.name
 
                         - if event.language.present? && @conference.languages_including_subs.count > 1
                           %span.badge.bg-secondary


### PR DESCRIPTION
Some track names are sentence-length and blow out the event blocks in the day grid and the track menu buttons. Cap track pills with CSS ellipsis truncation and keep the full name as a title tooltip.

Written as uppercase MIN() because libsass evaluates lowercase min() during both the compile and Sprockets compress passes and fails on the mixed rem/% units.