### PR TITLE
Add VoteBox feedback API endpoint

### DIFF
--- a/app/controllers/api/v1/feedback_controller.rb
+++ b/app/controllers/api/v1/feedback_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::FeedbackController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
   before_action :authenticate_by_token!
   before_action :check_feedback_enabled!
 
@@ -6,7 +8,7 @@ class Api::V1::FeedbackController < ActionController::API
     event = find_event(params[:event_id])
     return head :not_found unless event
 
-    feedback = event.event_feedbacks.new(rating: params[:rating], comment: params[:comment])
+    feedback = event.event_feedbacks.new(create_params)
     if feedback.save
       head :created
     else
@@ -15,7 +17,7 @@ class Api::V1::FeedbackController < ActionController::API
   end
 
   def batch
-    ratings = params[:ratings]
+    ratings = batch_params[:ratings]
     unless ratings.is_a?(Array) && ratings.any?
       return render json: { error: 'ratings must be a non-empty array' }, status: :unprocessable_entity
     end
@@ -33,19 +35,21 @@ class Api::V1::FeedbackController < ActionController::API
   private
 
   def authenticate_by_token!
-    token = bearer_token || params[:token]
-    conference = Conference.find_by(acronym: params[:conference_acronym], feedback_token: token)
-    return head :unauthorized unless conference
-    @conference = conference
+    authenticate_with_http_token do |token, _options|
+      next false if token.blank?
+
+      conference = Conference.find_by(acronym: params[:conference_acronym])
+      if conference && ActiveSupport::SecurityUtils.secure_compare(conference.feedback_token.to_s, token)
+        @conference = conference
+        true
+      else
+        false
+      end
+    end || head(:unauthorized)
   end
 
   def check_feedback_enabled!
-    head :forbidden unless @conference.feedback_enabled?
-  end
-
-  def bearer_token
-    header = request.headers['Authorization']
-    header&.start_with?('Bearer ') ? header.sub('Bearer ', '') : nil
+    head :forbidden unless @conference&.feedback_enabled?
   end
 
   def find_event(event_id)
@@ -62,5 +66,13 @@ class Api::V1::FeedbackController < ActionController::API
     else
       { error: "event #{entry[:event_id]}: #{feedback.errors.full_messages.join(', ')}" }
     end
+  end
+
+  def create_params
+    params.permit(:rating, :comment)
+  end
+
+  def batch_params
+    params.permit(ratings: [:event_id, :rating, :comment])
   end
 end

--- a/app/controllers/api/v1/feedback_controller.rb
+++ b/app/controllers/api/v1/feedback_controller.rb
@@ -12,14 +12,14 @@ class Api::V1::FeedbackController < ActionController::API
     if feedback.save
       head :created
     else
-      render json: { errors: feedback.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: feedback.errors.full_messages }, status: :unprocessable_content
     end
   end
 
   def batch
     ratings = batch_params[:ratings]
     unless ratings.is_a?(Array) && ratings.any?
-      return render json: { error: 'ratings must be a non-empty array' }, status: :unprocessable_entity
+      return render json: { error: 'ratings must be a non-empty array' }, status: :unprocessable_content
     end
 
     results = ratings.map { |entry| process_single(entry) }

--- a/app/controllers/api/v1/feedback_controller.rb
+++ b/app/controllers/api/v1/feedback_controller.rb
@@ -1,0 +1,66 @@
+class Api::V1::FeedbackController < ActionController::API
+  before_action :authenticate_by_token!
+  before_action :check_feedback_enabled!
+
+  def create
+    event = find_event(params[:event_id])
+    return head :not_found unless event
+
+    feedback = event.event_feedbacks.new(rating: params[:rating], comment: params[:comment])
+    if feedback.save
+      head :created
+    else
+      render json: { errors: feedback.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def batch
+    ratings = params[:ratings]
+    unless ratings.is_a?(Array) && ratings.any?
+      return render json: { error: 'ratings must be a non-empty array' }, status: :unprocessable_entity
+    end
+
+    results = ratings.map { |entry| process_single(entry) }
+    errors = results.select { |r| r[:error] }
+
+    if errors.any?
+      render json: { created: results.count { |r| r[:ok] }, errors: errors }, status: :multi_status
+    else
+      render json: { created: results.size }, status: :created
+    end
+  end
+
+  private
+
+  def authenticate_by_token!
+    token = bearer_token || params[:token]
+    conference = Conference.find_by(acronym: params[:conference_acronym], feedback_token: token)
+    return head :unauthorized unless conference
+    @conference = conference
+  end
+
+  def check_feedback_enabled!
+    head :forbidden unless @conference.feedback_enabled?
+  end
+
+  def bearer_token
+    header = request.headers['Authorization']
+    header&.start_with?('Bearer ') ? header.sub('Bearer ', '') : nil
+  end
+
+  def find_event(event_id)
+    @conference.events.is_public.accepted.scheduled.find_by(id: event_id)
+  end
+
+  def process_single(entry)
+    event = find_event(entry[:event_id])
+    return { error: "event #{entry[:event_id]} not found" } unless event
+
+    feedback = event.event_feedbacks.new(rating: entry[:rating], comment: entry[:comment])
+    if feedback.save
+      { ok: true }
+    else
+      { error: "event #{entry[:event_id]}: #{feedback.errors.full_messages.join(', ')}" }
+    end
+  end
+end

--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -80,7 +80,7 @@ class Cfp::PeopleController < ApplicationController
         format.xml  { render xml: @person, status: :created, location: @person }
       else
         format.html { render action: 'new' }
-        format.xml  { render xml: @person.errors, status: :unprocessable_entity }
+        format.xml  { render xml: @person.errors, status: :unprocessable_content }
       end
     end
   end
@@ -95,7 +95,7 @@ class Cfp::PeopleController < ApplicationController
       else
         flash_model_errors(@person)
         format.html { render action: 'edit' }
-        format.xml  { render xml: @person.errors, status: :unprocessable_entity }
+        format.xml  { render xml: @person.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/conferences_controller.rb
+++ b/app/controllers/conferences_controller.rb
@@ -168,6 +168,12 @@ class ConferencesController < BaseConferenceController
     redirect_to edit_notifications_conference_path, notice: t('conferences_module.notice_bulk_notification_queued', notification: params[:notification])
   end
 
+  def regenerate_feedback_token
+    authorize @conference, :orga?
+    @conference.regenerate_feedback_token!
+    redirect_to edit_conference_path, notice: t('conferences_module.notice_feedback_token_regenerated')
+  end
+
   # POST /conferences
   def create
     @conference = Conference.new(conference_params)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -322,8 +322,8 @@ class EventsController < BaseConferenceController
       else
         flash_model_errors(@event)
         @start_time_options = PossibleStartTimes.new(@event).all
-        format.html { render action: 'edit', status: :unprocessable_entity }
-        format.js { render json: @event.errors, status: :unprocessable_entity }
+        format.html { render action: 'edit', status: :unprocessable_content }
+        format.js { render json: @event.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/mail_templates_controller.rb
+++ b/app/controllers/mail_templates_controller.rb
@@ -47,7 +47,7 @@ class MailTemplatesController < BaseConferenceController
       else
         flash_model_errors(@mail_template)
         format.html { render action: 'edit' }
-        format.xml  { render xml: @mail_template.errors, status: :unprocessable_entity }
+        format.xml  { render xml: @mail_template.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/controllers/public/feedback_controller.rb
+++ b/app/controllers/public/feedback_controller.rb
@@ -17,7 +17,7 @@ class Public::FeedbackController < ApplicationController
         format.json { head :ok, status: :created }
       else
         format.html { render action: 'new' }
-        format.json { render json: @feedback.errors, status: :unprocessable_entity }
+        format.json { render json: @feedback.errors, status: :unprocessable_content }
       end
     end
   end

--- a/app/lib/import_export_helper.rb
+++ b/app/lib/import_export_helper.rb
@@ -24,7 +24,9 @@ class ImportExportHelper
 
     ActiveRecord::Base.transaction do
       save_schema_version
-      dump 'conference', @conference
+      # the feedback token is an API secret, it must not leave the database;
+      # imported conferences generate a fresh one on create
+      dump 'conference', @conference, except: %w(feedback_token)
       dump 'conference_tracks', @conference.tracks
       dump 'conference_cfp', @conference.call_for_participation
       dump 'conference_ticket_server', @conference.ticket_server
@@ -422,13 +424,13 @@ class ImportExportHelper
     dump name, arr
   end
 
-  def dump(name, obj)
+  def dump(name, obj, except: [])
     return if obj.nil?
     File.open(File.join(@export_dir, name) + '.yaml', 'w') { |f|
       if obj.respond_to?('collect')
-        f.puts obj.collect(&:attributes).to_yaml
+        f.puts obj.collect { |o| o.attributes.except(*except) }.to_yaml
       elsif obj.respond_to?('attributes')
-        f.puts obj.attributes.to_yaml
+        f.puts obj.attributes.except(*except).to_yaml
       else
         f.puts obj.to_yaml
       end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -2,6 +2,7 @@ class Conference < ApplicationRecord
   include ConferenceStatistics
   include SubConference
   include HasTicketServer
+  include UniqueToken
 
   has_many :availabilities, dependent: :destroy
   has_many :classifiers, dependent: :destroy
@@ -48,6 +49,7 @@ class Conference < ApplicationRecord
 
   before_validation :normalize_color
   after_update :update_timeslots
+  after_create :generate_feedback_token
 
   has_paper_trail
 
@@ -282,7 +284,17 @@ class Conference < ApplicationRecord
     update(allowed_event_timeslots: timeslots)
   end
 
+  def regenerate_feedback_token!
+    generate_token_for(:feedback_token)
+    save!
+  end
+
   private
+
+  def generate_feedback_token
+    generate_token_for(:feedback_token)
+    save!
+  end
 
   def normalize_color
     self.color = color.to_s.gsub(/\A#/, '') if color.present?

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -49,7 +49,7 @@ class Conference < ApplicationRecord
 
   before_validation :normalize_color
   after_update :update_timeslots
-  after_create :generate_feedback_token
+  before_create :generate_feedback_token
 
   has_paper_trail
 
@@ -293,7 +293,6 @@ class Conference < ApplicationRecord
 
   def generate_feedback_token
     generate_token_for(:feedback_token)
-    save!
   end
 
   def normalize_color

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -51,7 +51,8 @@ class Conference < ApplicationRecord
   after_update :update_timeslots
   before_create :generate_feedback_token
 
-  has_paper_trail
+  # the feedback token is an API secret, keep it out of the version history
+  has_paper_trail skip: [:feedback_token]
 
   has_attached_file :logo,
     styles: { tiny: '16x16>', small: '32x32>', large: '256x256>' },

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -86,6 +86,13 @@
         .col-12.col-md-6
           = f.input :transport_needs_enabled, as: :boolean, hint: t('conferences_module.inputs.hints.transport_needs_enabled')
           = f.input :bulk_notification_enabled, as: :boolean, hint: t('conferences_module.inputs.hints.bulk_notification_enabled')
+      - unless @conference.new_record?
+        .mt-3
+          %label.form-label= t('conferences_module.feedback_token')
+          .input-group
+            %input.form-control.font-monospace{ type: 'text', value: @conference.feedback_token, readonly: true }
+            = link_to t('conferences_module.regenerate_feedback_token'), regenerate_feedback_token_conference_path, method: :post, class: 'btn btn-outline-secondary', data: { confirm: t('conferences_module.confirm_regenerate_feedback_token') }
+          %div.form-text= t('conferences_module.inputs.hints.feedback_token')
   .card.shadow-sm.mb-4
     .card-header.d-flex.align-items-center
       %i.bi.bi-server.me-2

--- a/app/views/conferences/_form.html.haml
+++ b/app/views/conferences/_form.html.haml
@@ -86,13 +86,6 @@
         .col-12.col-md-6
           = f.input :transport_needs_enabled, as: :boolean, hint: t('conferences_module.inputs.hints.transport_needs_enabled')
           = f.input :bulk_notification_enabled, as: :boolean, hint: t('conferences_module.inputs.hints.bulk_notification_enabled')
-      - unless @conference.new_record?
-        .mt-3
-          %label.form-label= t('conferences_module.feedback_token')
-          .input-group
-            %input.form-control.font-monospace{ type: 'text', value: @conference.feedback_token, readonly: true }
-            = link_to t('conferences_module.regenerate_feedback_token'), regenerate_feedback_token_conference_path, method: :post, class: 'btn btn-outline-secondary', data: { confirm: t('conferences_module.confirm_regenerate_feedback_token') }
-          %div.form-text= t('conferences_module.inputs.hints.feedback_token')
   .card.shadow-sm.mb-4
     .card-header.d-flex.align-items-center
       %i.bi.bi-server.me-2

--- a/app/views/conferences/edit.html.haml
+++ b/app/views/conferences/edit.html.haml
@@ -10,3 +10,13 @@
   .row
     .col-md-12
       = render 'form'
+
+      .card.shadow-sm.mb-4
+        .card-header.d-flex.align-items-center
+          %i.bi.bi-star.me-2
+          %h5.mb-0= t('conferences_module.feedback_token')
+        .card-body
+          .d-flex.gap-2
+            %input.form-control.font-monospace{ type: 'text', value: @conference.feedback_token, readonly: true }
+            = button_to t('conferences_module.regenerate_feedback_token'), regenerate_feedback_token_conference_path, class: 'btn btn-outline-secondary text-nowrap', data: { controller: 'confirm', action: 'click->confirm#confirm', confirm_message_value: t('conferences_module.confirm_regenerate_feedback_token') }
+          %div.form-text= t('conferences_module.inputs.hints.feedback_token')

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -510,6 +510,12 @@ de:
         feedback_enabled: |
           Wenn aktiviert, enthält Ihr Programm-Export Links zu einem Feedback-Formular, in dem Teilnehmer
           ein Ereignis bewerten können.
+        feedback_token: |
+          Mit diesem Token authentifizieren sich VoteBox-Geräte, wenn sie Bewertungen
+          über die Feedback-API übermitteln. Halten Sie ihn geheim. POST an
+          /api/v1/{acronym}/events/{event_id}/feedback mit {"rating": 1-5} oder an
+          /api/v1/{acronym}/feedback/batch mit {"ratings": [{"event_id": N, "rating": 1-5}]}.
+          Übergeben Sie den Token im Header "Authorization: Token token={token}".
         max_timeslots: Was ist die maximale Länge einer Einreichung (gerechnet in Zeit-Slots)?
         timeslot_duration: |
           Wie lange sollen die kleinsten Zeit-Slots dauern? Hierdurch wird das grundlegende Zeit-Raster
@@ -548,6 +554,10 @@ de:
     notice_conference_created: Die Konferenz wurde erfolgreich erstellt.
     notice_conference_not_updated: Konferenz wurde nicht aktualisiert.
     notice_conference_updated: Die Konferenz wurde erfolgreich aktualisiert.
+    notice_feedback_token_regenerated: Der Feedback-API-Token wurde neu generiert.
+    feedback_token: Feedback-API-Token
+    regenerate_feedback_token: Token neu generieren
+    confirm_regenerate_feedback_token: "Feedback-API-Token neu generieren? Alle VoteBoxen, die den alten Token verwenden, müssen aktualisiert werden."
     past_conferences: Frühere Konferenzen
     recent_changes: Letzte Änderungen
     recent_changes_text: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,6 +524,12 @@ en:
         feedback_enabled: |
           If you enable this, your program export will include links to a feedback
           form where attendees can rate an event.
+        feedback_token: |
+          Use this token to authenticate VoteBox devices when submitting ratings
+          via the feedback API. Keep it secret. POST to
+          /api/v1/{acronym}/events/{event_id}/feedback with {"rating": 1-5} or
+          /api/v1/{acronym}/feedback/batch with {"ratings": [{"event_id": N, "rating": 1-5}]}.
+          Pass the token as "Authorization: Bearer {token}" header or ?token= parameter.
         max_timeslots: What is the maximum length of a single event (e.g. a single talk)?
         timeslot_duration: |
           How long do you want the smallest timeslots to be? This essentially
@@ -567,6 +573,10 @@ en:
     notice_conference_created: Conference was successfully created.
     notice_conference_not_updated: Conference was not updated.
     notice_conference_updated: Conference was successfully updated.
+    notice_feedback_token_regenerated: Feedback API token has been regenerated.
+    feedback_token: Feedback API Token
+    regenerate_feedback_token: Regenerate Token
+    confirm_regenerate_feedback_token: "Regenerate the feedback API token? Any VoteBoxes using the old token will need to be updated."
     past_conferences: Past Conferences
     recent_changes: Recent changes
     recent_changes_text: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -529,7 +529,7 @@ en:
           via the feedback API. Keep it secret. POST to
           /api/v1/{acronym}/events/{event_id}/feedback with {"rating": 1-5} or
           /api/v1/{acronym}/feedback/batch with {"ratings": [{"event_id": N, "rating": 1-5}]}.
-          Pass the token as "Authorization: Bearer {token}" header or ?token= parameter.
+          Pass the token as "Authorization: Token token={token}" header.
         max_timeslots: What is the maximum length of a single event (e.g. a single talk)?
         timeslot_duration: |
           How long do you want the smallest timeslots to be? This essentially

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,7 +156,7 @@ Rails.application.routes.draw do
           patch :toggle_locked
         end
         resource :event_rating
-        resources :event_feedbacks
+        resources :event_feedbacks, only: %i(index create)
         get 'history' => 'events#history'
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,15 @@ Rails.application.routes.draw do
   # Health check endpoint for Kubernetes probes
   get '/health' => 'health#show'
 
+  namespace :api do
+    namespace :v1 do
+      scope path: '/:conference_acronym' do
+        post '/events/:event_id/feedback' => 'feedback#create', as: 'api_v1_event_feedback'
+        post '/feedback/batch' => 'feedback#batch', as: 'api_v1_feedback_batch'
+      end
+    end
+  end
+
   devise_for :users, controllers: {
     registrations: 'auth/registrations',
     sessions: 'auth/sessions',
@@ -101,6 +110,7 @@ Rails.application.routes.draw do
         get :edit_ticket_server
         get :edit_notifications
         post :send_notification
+        post :regenerate_feedback_token
       end
       get '/conferences/default_notifications' => 'conferences#default_notifications', as: 'conferences_default_notifications'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       scope path: '/:conference_acronym' do
-        post '/events/:event_id/feedback' => 'feedback#create', as: 'api_v1_event_feedback'
-        post '/feedback/batch' => 'feedback#batch', as: 'api_v1_feedback_batch'
+        post '/events/:event_id/feedback' => 'feedback#create', as: 'event_feedback'
+        post '/feedback/batch' => 'feedback#batch', as: 'feedback_batch'
       end
     end
   end

--- a/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
+++ b/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
@@ -1,6 +1,15 @@
 class AddFeedbackTokenToConferences < ActiveRecord::Migration[7.1]
-  def change
+  def up
     add_column :conferences, :feedback_token, :string
+
+    # Generate tokens for existing conferences
+    Conference.reset_column_information
+    Conference.find_each(&:regenerate_feedback_token!)
+
     add_index :conferences, :feedback_token, unique: true
+  end
+
+  def down
+    remove_column :conferences, :feedback_token
   end
 end

--- a/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
+++ b/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
@@ -1,0 +1,6 @@
+class AddFeedbackTokenToConferences < ActiveRecord::Migration[7.1]
+  def change
+    add_column :conferences, :feedback_token, :string
+    add_index :conferences, :feedback_token, unique: true
+  end
+end

--- a/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
+++ b/db/migrate/20260714000000_add_feedback_token_to_conferences.rb
@@ -2,9 +2,14 @@ class AddFeedbackTokenToConferences < ActiveRecord::Migration[7.1]
   def up
     add_column :conferences, :feedback_token, :string
 
-    # Generate tokens for existing conferences
+    # Generate tokens for existing conferences. update_column skips
+    # validations, callbacks and paper_trail, so legacy records can't abort
+    # the migration and no token ends up in the version history.
     Conference.reset_column_information
-    Conference.find_each(&:regenerate_feedback_token!)
+    Conference.find_each do |conference|
+      conference.generate_token_for(:feedback_token)
+      conference.update_column(:feedback_token, conference.feedback_token)
+    end
 
     add_index :conferences, :feedback_token, unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -210,7 +210,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
 
   create_table "events", force: :cascade do |t|
     t.integer "conference_id", null: false
-    t.string "title"
+    t.string "title", limit: 255
     t.string "subtitle", limit: 255
     t.string "event_type", limit: 255, default: "talk"
     t.integer "time_slots", default: 3
@@ -238,11 +238,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
     t.string "guid", limit: 255
     t.boolean "do_not_record", default: false
     t.string "recording_license", limit: 255
-    t.integer "number_of_repeats", default: 1
-    t.text "other_locations"
-    t.text "methods"
-    t.text "target_audience_experience"
-    t.text "target_audience_experience_text"
     t.text "tech_rider"
     t.string "invite_token"
     t.string "video_url", limit: 255
@@ -497,13 +492,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
 
   add_foreign_key "average_review_scores", "events"
   add_foreign_key "average_review_scores", "review_metrics"
-  add_foreign_key "classifiers", "conferences"
-  add_foreign_key "event_classifiers", "classifiers"
-  add_foreign_key "event_classifiers", "events"
   add_foreign_key "event_translations", "events"
   add_foreign_key "person_translations", "people"
-  add_foreign_key "review_metrics", "conferences"
-  add_foreign_key "review_scores", "event_ratings"
-  add_foreign_key "review_scores", "review_metrics"
   add_foreign_key "track_translations", "tracks"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,8 +49,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
     t.string "name"
     t.string "description"
     t.integer "conference_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["conference_id"], name: "index_classifiers_on_conference_id"
   end
 
@@ -154,8 +154,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
     t.integer "value", default: 0
     t.integer "classifier_id"
     t.integer "event_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["classifier_id"], name: "index_event_classifiers_on_classifier_id"
     t.index ["event_id"], name: "index_event_classifiers_on_event_id"
   end
@@ -210,7 +210,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
 
   create_table "events", force: :cascade do |t|
     t.integer "conference_id", null: false
-    t.string "title", limit: 255
+    t.string "title"
     t.string "subtitle", limit: 255
     t.string "event_type", limit: 255, default: "talk"
     t.integer "time_slots", default: 3
@@ -238,6 +238,11 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
     t.string "guid", limit: 255
     t.boolean "do_not_record", default: false
     t.string "recording_license", limit: 255
+    t.integer "number_of_repeats", default: 1
+    t.text "other_locations"
+    t.text "methods"
+    t.text "target_audience_experience"
+    t.text "target_audience_experience_text"
     t.text "tech_rider"
     t.string "invite_token"
     t.string "video_url", limit: 255
@@ -492,7 +497,13 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
 
   add_foreign_key "average_review_scores", "events"
   add_foreign_key "average_review_scores", "review_metrics"
+  add_foreign_key "classifiers", "conferences"
+  add_foreign_key "event_classifiers", "classifiers"
+  add_foreign_key "event_classifiers", "events"
   add_foreign_key "event_translations", "events"
   add_foreign_key "person_translations", "people"
+  add_foreign_key "review_metrics", "conferences"
+  add_foreign_key "review_scores", "event_ratings"
+  add_foreign_key "review_scores", "review_metrics"
   add_foreign_key "track_translations", "tracks"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
   create_table "availabilities", force: :cascade do |t|
     t.integer "person_id"
     t.integer "conference_id"
@@ -49,8 +49,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
     t.string "name"
     t.string "description"
     t.integer "conference_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["conference_id"], name: "index_classifiers_on_conference_id"
   end
 
@@ -112,7 +112,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
     t.string "allowed_event_timeslots_csv", limit: 400
     t.string "bcc_address", limit: 255
     t.boolean "auto_lock_on_confirm", default: false
+    t.string "feedback_token"
     t.index ["acronym"], name: "index_conferences_on_acronym"
+    t.index ["feedback_token"], name: "index_conferences_on_feedback_token", unique: true
     t.index ["parent_id"], name: "index_conferences_on_parent_id"
   end
 
@@ -152,8 +154,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
     t.integer "value", default: 0
     t.integer "classifier_id"
     t.integer "event_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["classifier_id"], name: "index_event_classifiers_on_classifier_id"
     t.index ["event_id"], name: "index_event_classifiers_on_event_id"
   end

--- a/db/schema.rb-mysql
+++ b/db/schema.rb-mysql
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_14_000000) do
   connection.execute("SET FOREIGN_KEY_CHECKS = 0") if connection.adapter_name == 'Mysql2'
 
   create_table "availabilities", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -114,7 +114,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_10_31_000000) do
     t.string "allowed_event_timeslots_csv", limit: 400
     t.string "bcc_address"
     t.boolean "auto_lock_on_confirm", default: false
+    t.string "feedback_token"
     t.index ["acronym"], name: "index_conferences_on_acronym"
+    t.index ["feedback_token"], name: "index_conferences_on_feedback_token", unique: true
     t.index ["parent_id"], name: "index_conferences_on_parent_id"
   end
 

--- a/test/controllers/api/v1/feedback_controller_test.rb
+++ b/test/controllers/api/v1/feedback_controller_test.rb
@@ -1,0 +1,109 @@
+require 'test_helper'
+
+class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @conference = create(:three_day_conference_with_events)
+    @conference.update!(feedback_enabled: true)
+    @event = @conference.events.first
+    @event.update!(public: true, state: :scheduled, room: @conference.rooms.first, start_time: Time.now)
+    @token = @conference.feedback_token
+  end
+
+  test 'creates feedback with bearer token' do
+    assert_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 4 },
+           headers: { 'Authorization' => "Bearer #{@token}" }
+    end
+    assert_response :created
+  end
+
+  test 'creates feedback with token query param' do
+    assert_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 3, token: @token }
+    end
+    assert_response :created
+  end
+
+  test 'rejects feedback with wrong token' do
+    assert_no_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 4 },
+           headers: { 'Authorization' => 'Bearer wrong' }
+    end
+    assert_response :unauthorized
+  end
+
+  test 'rejects feedback without token' do
+    assert_no_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 4 }
+    end
+    assert_response :unauthorized
+  end
+
+  test 'rejects feedback when feedback disabled' do
+    @conference.update!(feedback_enabled: false)
+    assert_no_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 4 },
+           headers: { 'Authorization' => "Bearer #{@token}" }
+    end
+    assert_response :forbidden
+  end
+
+  test 'rejects invalid rating' do
+    assert_no_difference 'EventFeedback.count' do
+      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
+           params: { rating: 6 },
+           headers: { 'Authorization' => "Bearer #{@token}" }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test 'returns not found for unknown event' do
+    post "/api/v1/#{@conference.acronym}/events/0/feedback",
+         params: { rating: 3 },
+         headers: { 'Authorization' => "Bearer #{@token}" }
+    assert_response :not_found
+  end
+
+  test 'batch creates multiple feedbacks' do
+    event2 = create(:event, conference: @conference, public: true, state: :scheduled,
+                    room: @conference.rooms.first, start_time: Time.now)
+    assert_difference 'EventFeedback.count', 2 do
+      post "/api/v1/#{@conference.acronym}/feedback/batch",
+           params: { ratings: [
+             { event_id: @event.id, rating: 5 },
+             { event_id: event2.id, rating: 2 }
+           ] },
+           headers: { 'Authorization' => "Bearer #{@token}" },
+           as: :json
+    end
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal 2, body['created']
+  end
+
+  test 'batch returns multi_status when some fail' do
+    assert_difference 'EventFeedback.count', 1 do
+      post "/api/v1/#{@conference.acronym}/feedback/batch",
+           params: { ratings: [
+             { event_id: @event.id, rating: 4 },
+             { event_id: 0, rating: 3 }
+           ] },
+           headers: { 'Authorization' => "Bearer #{@token}" },
+           as: :json
+    end
+    assert_response :multi_status
+  end
+
+  test 'batch rejects empty ratings array' do
+    post "/api/v1/#{@conference.acronym}/feedback/batch",
+         params: { ratings: [] },
+         headers: { 'Authorization' => "Bearer #{@token}" },
+         as: :json
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/api/v1/feedback_controller_test.rb
+++ b/test/controllers/api/v1/feedback_controller_test.rb
@@ -51,7 +51,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
            params: { rating: 6 },
            headers: { 'Authorization' => "Token token=#{@token}" }
     end
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 
   test 'returns not found for unknown event' do
@@ -96,6 +96,6 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
          params: { ratings: [] },
          headers: { 'Authorization' => "Token token=#{@token}" },
          as: :json
-    assert_response :unprocessable_entity
+    assert_response :unprocessable_content
   end
 end

--- a/test/controllers/api/v1/feedback_controller_test.rb
+++ b/test/controllers/api/v1/feedback_controller_test.rb
@@ -9,19 +9,11 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
     @token = @conference.feedback_token
   end
 
-  test 'creates feedback with bearer token' do
+  test 'creates feedback with standard token header' do
     assert_difference 'EventFeedback.count' do
       post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
            params: { rating: 4 },
-           headers: { 'Authorization' => "Bearer #{@token}" }
-    end
-    assert_response :created
-  end
-
-  test 'creates feedback with token query param' do
-    assert_difference 'EventFeedback.count' do
-      post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
-           params: { rating: 3, token: @token }
+           headers: { 'Authorization' => "Token token=#{@token}" }
     end
     assert_response :created
   end
@@ -30,7 +22,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'EventFeedback.count' do
       post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
            params: { rating: 4 },
-           headers: { 'Authorization' => 'Bearer wrong' }
+           headers: { 'Authorization' => 'Token token=wrong' }
     end
     assert_response :unauthorized
   end
@@ -48,7 +40,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'EventFeedback.count' do
       post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
            params: { rating: 4 },
-           headers: { 'Authorization' => "Bearer #{@token}" }
+           headers: { 'Authorization' => "Token token=#{@token}" }
     end
     assert_response :forbidden
   end
@@ -57,7 +49,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference 'EventFeedback.count' do
       post "/api/v1/#{@conference.acronym}/events/#{@event.id}/feedback",
            params: { rating: 6 },
-           headers: { 'Authorization' => "Bearer #{@token}" }
+           headers: { 'Authorization' => "Token token=#{@token}" }
     end
     assert_response :unprocessable_entity
   end
@@ -65,7 +57,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
   test 'returns not found for unknown event' do
     post "/api/v1/#{@conference.acronym}/events/0/feedback",
          params: { rating: 3 },
-         headers: { 'Authorization' => "Bearer #{@token}" }
+         headers: { 'Authorization' => "Token token=#{@token}" }
     assert_response :not_found
   end
 
@@ -78,7 +70,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
              { event_id: @event.id, rating: 5 },
              { event_id: event2.id, rating: 2 }
            ] },
-           headers: { 'Authorization' => "Bearer #{@token}" },
+           headers: { 'Authorization' => "Token token=#{@token}" },
            as: :json
     end
     assert_response :created
@@ -93,7 +85,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
              { event_id: @event.id, rating: 4 },
              { event_id: 0, rating: 3 }
            ] },
-           headers: { 'Authorization' => "Bearer #{@token}" },
+           headers: { 'Authorization' => "Token token=#{@token}" },
            as: :json
     end
     assert_response :multi_status
@@ -102,7 +94,7 @@ class Api::V1::FeedbackControllerTest < ActionDispatch::IntegrationTest
   test 'batch rejects empty ratings array' do
     post "/api/v1/#{@conference.acronym}/feedback/batch",
          params: { ratings: [] },
-         headers: { 'Authorization' => "Bearer #{@token}" },
+         headers: { 'Authorization' => "Token token=#{@token}" },
          as: :json
     assert_response :unprocessable_entity
   end

--- a/test/tasks/rake_task_export_import_conference_test.rb
+++ b/test/tasks/rake_task_export_import_conference_test.rb
@@ -67,11 +67,15 @@ class RakeTaskExportImportConferenceTest < ActiveSupport::TestCase
     attributes_to_compare -= [ "id" ] # Updated during re-import
     attributes_to_compare -= [ "acronym", "title" ] # Updated by this test
     attributes_to_compare -= [ "created_at", "updated_at" ] # Modified to import time
+    attributes_to_compare -= [ "feedback_token" ] # Secret, stripped from exports
 
     attributes_to_compare.each { |attr|
       original = conf_attrs[attr]
       imported = new_conf_attrs[attr]
       assert original == imported, "conference #{attr} should be identical. original is #{original} ; imported is #{imported}"
     }
+
+    assert new_conf_attrs["feedback_token"].present?, "imported conference has a feedback_token"
+    assert new_conf_attrs["feedback_token"] != conf_attrs["feedback_token"], "imported conference got a fresh feedback_token"
   end
 end


### PR DESCRIPTION
Physical voting devices can now submit talk ratings via a token-authenticated HTTP API without requiring user login or CSRF handling.

Adds POST /api/v1/:conference_acronym/events/:event_id/feedback (single) and POST /api/v1/:conference_acronym/feedback/batch (bulk). Token is generated per conference, displayed in the admin settings page with a regenerate button.

Refers to #1045